### PR TITLE
cppQML: deps: add qt6-declarative-dev

### DIFF
--- a/cppQML/.conf/deps.json
+++ b/cppQML/.conf/deps.json
@@ -9,6 +9,7 @@
         "g++",
         "qmake6",
         "qt6-base-dev",
+        "qt6-declarative-dev",
         "netcat-traditional"
     ]
 }


### PR DESCRIPTION
Hi,

My PC has a recent installation of Ubuntu 22.04 LTS. After installing the suggested dependencies, the task `build-debug-x86-local` failed with the following error:

```
Executing task: qmake -o x86_64/Makefile CONFIG+=debug CONFIG+=qml_debug 

Project ERROR: Unknown module(s) in QT: qml quick

 *  The terminal process "/usr/bin/bash '-c', 'qmake -o x86_64/Makefile CONFIG+=debug CONFIG+=qml_debug'" failed to launch (exit code: 3). 
 *  Terminal will be reused by tasks, press any key to close it.
```

After some searching, I found out that the package `qt6-declarative-dev` was missing. After installing it, qmake executed successfully.