### PR TITLE
dotnet-console: Add SSH_DEBUG_PORT

### DIFF
--- a/dotnet-console/.vscode/tasks.json
+++ b/dotnet-console/.vscode/tasks.json
@@ -149,6 +149,8 @@
                 "build",
                 "--build-arg",
                 "IMAGE_ARCH=arm",
+                "--build-arg",
+                "SSH_DEBUG_PORT=${config:torizon_debug_ssh_port}",
                 "__container__-debug"
             ],
             "dependsOrder": "sequence",
@@ -434,6 +436,8 @@
                 "build",
                 "--build-arg",
                 "IMAGE_ARCH=amd64",
+                "--build-arg",
+                "SSH_DEBUG_PORT=${config:torizon_debug_ssh_port}",
                 "__container__-debug"
             ],
             "dependsOrder": "sequence",
@@ -719,6 +723,8 @@
                 "build",
                 "--build-arg",
                 "IMAGE_ARCH=arm64",
+                "--build-arg",
+                "SSH_DEBUG_PORT=${config:torizon_debug_ssh_port}",
                 "__container__-debug"
             ],
             "dependsOrder": "sequence",

--- a/dotnet-console/Dockerfile.debug
+++ b/dotnet-console/Dockerfile.debug
@@ -16,6 +16,11 @@ ARG BASE_VERSION=2-6.0
 ##
 ARG APP_EXECUTABLE=__change__
 
+##
+# Debug port
+##
+ARG SSH_DEBUG_PORT=
+
 # BUILD ------------------------------------------------------------------------
 ##
 # Deploy Step .NET
@@ -25,10 +30,11 @@ FROM --platform=linux/${IMAGE_ARCH} \
 
 ARG IMAGE_ARCH
 ARG APP_EXECUTABLE
+ARG SSH_DEBUG_PORT
 ENV APP_EXECUTABLE ${APP_EXECUTABLE}
 
 # SSH for remote debug
-EXPOSE 2222
+EXPOSE ${SSH_DEBUG_PORT}
 ARG SSHUSERNAME=torizon
 
 # Make sure we don't get notifications we can't answer during building.
@@ -72,7 +78,7 @@ RUN mkdir /var/run/sshd && \
         then cp /id_rsa.pub /home/$SSHUSERNAME/.ssh/authorized_keys ; \
         else cp /id_rsa.pub /root/.ssh/authorized_keys ; fi && \
     echo "PermitUserEnvironment yes" >> /etc/ssh/sshd_config && \
-    echo "Port 2222" >> /etc/ssh/sshd_config && \
+    echo "Port ${SSH_DEBUG_PORT}" >> /etc/ssh/sshd_config && \
     su -c "env" $SSHUSERNAME > /etc/environment
 
 RUN rm -r /etc/ssh/ssh*key && \


### PR DESCRIPTION
This is needed to be able to use ports for multi root projects

Signed-off-by: Matheus Castello <matheus.castello@toradex.com>