### PR TITLE
cppQML: Add Local x86 Qt Creator

### DIFF
--- a/cppQML/.vscode/launch.json
+++ b/cppQML/.vscode/launch.json
@@ -7,6 +7,38 @@
             "request": "launch",
             "program": "${workspaceFolder}/x86_64/debug/__change__",
             "args": [
+                //"-qmljsdebugger=port:${config:torizon_debug_port3},block,services:DebugMessages,QmlDebugger,V8Debugger,QmlInspector,DebugTranslation"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}",
+            "environment": [
+                {
+                    "name": "QT_LOGGING_RULES",
+                    "value": "*.debug=true; qt.*.debug=false"
+                }
+            ],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description":  "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "build-debug-x86-local"
+        },
+        {
+            "name": "Local x86 Qt Creator",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/x86_64/debug/__change__",
+            "args": [
                 "-qmljsdebugger=port:${config:torizon_debug_port3},block,services:DebugMessages,QmlDebugger,V8Debugger,QmlInspector,DebugTranslation"
             ],
             "stopAtEntry": false,


### PR DESCRIPTION
Now the Local x86 run without the block for the QmlDebugger, and the Local x86 Qt Creator launch with the block for QmlDebugger and waits for the Qt Creator connection

Signed-off-by: Matheus Castello <matheus.castello@toradex.com>