### PR TITLE
assets/tasks/common.json: Set GPU variable on debug

### DIFF
--- a/assets/tasks/common.json
+++ b/assets/tasks/common.json
@@ -902,7 +902,7 @@
                 "-o",
                 "StrictHostKeyChecking=no",
                 "torizon@${config:torizon_ip}",
-                "LOCAL_REGISTRY=${config:host_ip} TAG=arm64 docker-compose up -d __container__-debug"
+                "LOCAL_REGISTRY=${config:host_ip} TAG=arm64 GPU=${config:torizon_gpu} docker-compose up -d __container__-debug"
             ],
             "dependsOrder": "sequence",
             "dependsOn": [
@@ -928,7 +928,7 @@
                 "-o",
                 "StrictHostKeyChecking=no",
                 "torizon@${config:torizon_ip}",
-                "LOCAL_REGISTRY=${config:host_ip} TAG=arm docker-compose up -d __container__-debug"
+                "LOCAL_REGISTRY=${config:host_ip} TAG=arm GPU=${config:torizon_gpu} docker-compose up -d __container__-debug"
             ],
             "dependsOrder": "sequence",
             "dependsOn": [
@@ -954,7 +954,7 @@
                 "-o",
                 "StrictHostKeyChecking=no",
                 "torizon@${config:torizon_ip}",
-                "LOCAL_REGISTRY=${config:host_ip} TAG=amd64 docker-compose up -d __container__-debug"
+                "LOCAL_REGISTRY=${config:host_ip} TAG=amd64 GPU=${config:torizon_gpu} docker-compose up -d __container__-debug"
             ],
             "dependsOrder": "sequence",
             "dependsOn": [
@@ -980,7 +980,7 @@
                 "-o",
                 "StrictHostKeyChecking=no",
                 "torizon@${config:torizon_ip}",
-                "LOCAL_REGISTRY=${config:host_ip} TAG=x86 docker-compose up -d __container__-debug"
+                "LOCAL_REGISTRY=${config:host_ip} TAG=x86 GPU=${config:torizon_gpu} docker-compose up -d __container__-debug"
             ],
             "dependsOrder": "sequence",
             "dependsOn": [
@@ -1006,7 +1006,7 @@
                 "-o",
                 "StrictHostKeyChecking=no",
                 "torizon@${config:torizon_ip}",
-                "LOCAL_REGISTRY=${config:host_ip} TAG=riscv64 docker-compose up -d __container__-debug"
+                "LOCAL_REGISTRY=${config:host_ip} TAG=riscv64 GPU=${config:torizon_gpu} docker-compose up -d __container__-debug"
             ],
             "dependsOrder": "sequence",
             "dependsOn": [


### PR DESCRIPTION
This is necessary for SoMs that use a Vivante GPU, which uses weston-vivante instead of weston.

Signed-off-by: morishitalucas@gmail.com