### PR TITLE
Fix: Change debugpy wait time to allow it to start on all SoMs

### DIFF
--- a/python3Console/.vscode/tasks.json
+++ b/python3Console/.vscode/tasks.json
@@ -32,7 +32,7 @@
             "command": "sleep",
             "type": "process",
             "args": [
-                "2",
+                "4",
             ],            
             "dependsOn": [
                 "validate-settings",
@@ -111,7 +111,7 @@
             "command": "sleep",
             "type": "process",
             "args": [
-                "2",
+                "4",
             ],            
             "dependsOn": [
                 "validate-settings",

--- a/python3Pyside2QML/.vscode/tasks.json
+++ b/python3Pyside2QML/.vscode/tasks.json
@@ -32,7 +32,7 @@
             "command": "sleep",
             "type": "process",
             "args": [
-                "2",
+                "4",
             ],            
             "dependsOn": [
                 "validate-settings",
@@ -111,7 +111,7 @@
             "command": "sleep",
             "type": "process",
             "args": [
-                "2",
+                "4",
             ],            
             "dependsOn": [
                 "validate-settings",


### PR DESCRIPTION
Increase the wait time for the debugpy command to execute, as it was not being enough on boards like the IMX6ULL.