### PR TITLE
share WSL ports Series

### DIFF
--- a/assets/tasks/common.json
+++ b/assets/tasks/common.json
@@ -289,10 +289,14 @@
                 "clear": false
             },
             "args": [
+                "-nop",
                 "-file",
                 "${workspaceFolder}/.conf/runContainerIfNotExists.ps1",
+                "-ContainerRuntime",
                 "docker",
-                "'-d -p 5002:5000 --restart=always registry:2'",
+                "-RunArguments",
+                "'\"-d -p 5002:5000 --restart=always registry:2\"'",
+                "-ContainerName",
                 "registry"
             ],
             "dependsOrder": "sequence",
@@ -316,8 +320,11 @@
             },
             "args": [
                 "${workspaceFolder}/.conf/runContainerIfNotExists.ps1",
+                "-ContainerRuntime",
                 "docker",
+                "-RunArguments",
                 "'--rm --privileged torizon/binfmt'",
+                "-ContainerName",
                 "binfmt"
             ],
             "dependsOrder": "sequence",
@@ -340,7 +347,8 @@
                 "clear": false
             },
             "args": [
-                "${workspaceFolder}/.conf/shareWSLPorts.ps1"
+                "${workspaceFolder}/.conf/shareWSLPorts.ps1",
+                "${workspaceFolder}"
             ],
             "dependsOrder": "sequence",
             "icon": {

--- a/scripts/runContainerIfNotExists.ps1
+++ b/scripts/runContainerIfNotExists.ps1
@@ -14,7 +14,11 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
     'PSAvoidGlobalVars', ""
 )]
-param()
+param(
+    [string] $ContainerRuntime,
+    [string] $RunArguments,
+    [string] $ContainerName
+)
 
 $env:DOCKER_HOST = ""
 
@@ -23,9 +27,14 @@ if ($Env:GITLAB_CI -eq $true) {
     $Env:DOCKER_HOST = "tcp://docker:2375"
 }
 
-$_containerRuntime = $args[0]
-$_runArguments = $args[1].Trim("'").Trim('"');
-$_containerName = $args[2]
+$_containerRuntime = $ContainerRuntime
+$_runArguments = $RunArguments.Trim("'").Trim('"');
+$_containerName = $ContainerName
+
+# debug
+Write-Host "Container Runtime: $_containerRuntime"
+Write-Host "Run Arguments: $_runArguments"
+Write-Host "Container Name: $_containerName"
 
 $_containerInfo = 
     Invoke-Expression "$_containerRuntime container inspect $_containerName" | `

--- a/scripts/shareWSLPorts.ps1
+++ b/scripts/shareWSLPorts.ps1
@@ -2,6 +2,7 @@
 # THIS NEED TO BE SUPPORTED ON THE WINDOWS POWERSHELL
 # this only makes sense for WSL
 if ($null -ne $env:WSL_DISTRO_NAME) {
+    $_workspace = $args[0]
     $remoteport = bash -c "ifconfig eth0 | grep 'inet '"
     $found = $remoteport -match '\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}';
 
@@ -36,7 +37,7 @@ if ($null -ne $env:WSL_DISTRO_NAME) {
         $superScript = "$($superScript) (netsh interface portproxy delete v4tov4 listenport=$port listenaddress=$addr) -or `$true ; ";
     }
 
-    $superScript = "$($superScript) wsl -e --shell-type standard -- pwsh ./.vscode/tasks.ps1 run run-docker-registry ; "
+    $superScript = "$($superScript) wsl -e pwsh -nop -File $_workspace/.vscode/tasks.ps1 run run-docker-registry-wsl ; "
 
     for( $i = 0; $i -lt $ports.length; $i++ ){
         $port = $ports[$i];
@@ -52,4 +53,6 @@ if ($null -ne $env:WSL_DISTRO_NAME) {
 
     # cspell:disable-next-line
     powershell.exe -NoProfile -C "start-process powershell -verb runas -ArgumentList '-NoProfile -C `"$superScript echo done`"'"
+    # for debug comment the above and uncomment the below
+    #powershell.exe -NoProfile -C "start-process powershell -verb runas -ArgumentList '-NoProfile -C `"$superScript echo done; Read-Host ; `"'"
 }

--- a/tcb/.vscode/tasks.json
+++ b/tcb/.vscode/tasks.json
@@ -66,10 +66,14 @@
                 "clear": false
             },
             "args": [
+                "-nop",
                 "-file",
                 "${workspaceFolder}/.conf/runContainerIfNotExists.ps1",
+                "-ContainerRuntime",
                 "docker",
-                "'-d -p 5002:5000 --restart=always registry:2'",
+                "-RunArguments",
+                "'\"-d -p 5002:5000 --restart=always registry:2\"'",
+                "-ContainerName",
                 "registry"
             ],
             "dependsOrder": "sequence",
@@ -93,8 +97,11 @@
             },
             "args": [
                 "${workspaceFolder}/.conf/runContainerIfNotExists.ps1",
+                "-ContainerRuntime",
                 "docker",
-                "'--rm -it --privileged torizon/binfmt'",
+                "-RunArguments",
+                "'--rm --privileged torizon/binfmt'",
+                "-ContainerName",
                 "binfmt"
             ],
             "dependsOrder": "sequence",


### PR DESCRIPTION
These are some changes and fixes for the share WSL ports scenario.
In some cases the `run-docker-registry` can not work telling that the `5002` is already in use, but the process that is using it is the Windows firewall utils. So this series adds the configurations and fixes to run the registry as soon the delete the old port from firewall.