### PR TITLE
scripts: initWorkspace: Enforce right permissions to .conf/id_rsa

### DIFF
--- a/scripts/initWorkspace.ps1
+++ b/scripts/initWorkspace.ps1
@@ -75,6 +75,9 @@ if (!(Test-Path ./.conf/.template)) {
     $_settings | ConvertTo-Json -Depth 100 `
         | Set-Content ./.vscode/settings.json
 
+    # enforce 0400 to ./.conf/id_rsa
+    chmod 0400 ./.conf/id_rsa
+
     Write-Host ""
     Write-Host `
         -ForegroundColor Green `


### PR DESCRIPTION
In some scenarios we can get an debug id_rsa file with the wrong permissions, so let's enforce the 0400 like we do on vs code side.