### PR TITLE
scripts: createFromTemplate: Fix telemetry URL

### DIFF
--- a/nodeJSTypeScript/Dockerfile.debug
+++ b/nodeJSTypeScript/Dockerfile.debug
@@ -28,7 +28,7 @@ ARG SSHUSERNAME=
 
 # BUILD ------------------------------------------------------------------------
 ##
-# Deploy Step .NET Uno
+# Deploy Step
 ##
 FROM --platform=linux/${IMAGE_ARCH} \
     torizon/debian:${BASE_VERSION} AS Debug

--- a/scripts/createFromTemplate.ps1
+++ b/scripts/createFromTemplate.ps1
@@ -95,7 +95,7 @@ if ($_TELEMETRY -eq $true) {
         Invoke-WebRequest `
             -UseBasicParsing `
             -Uri `
-                "http://castello.dev.br/api/template/plus" `
+                "http://tie.switzerlandnorth.cloudapp.azure.com/api/template/plus" `
             -Body $_query `
             -Method Get | Out-Null
     } catch {


### PR DESCRIPTION
Moving the telemetry data from personal server and use the new one maintained by Toradex.