### PR TITLE
cppQML: c_cpp_properties: Update cppStandard to gnu++17

### DIFF
--- a/cppQML/.conf/update.json
+++ b/cppQML/.conf/update.json
@@ -6,5 +6,9 @@
     {
         "source": ".vscode/launch.json",
         "target": ".vscode/launch.json"
-    }    
+    },
+    {
+        "source": ".vscode/c_cpp_properties.json",
+        "target": ".vscode/c_cpp_properties.json"
+    }
 ]

--- a/cppQML/.vscode/c_cpp_properties.json
+++ b/cppQML/.vscode/c_cpp_properties.json
@@ -9,7 +9,7 @@
             "defines": [],
             "compilerPath": "/usr/bin/gcc",
             "cStandard": "gnu17",
-            "cppStandard": "gnu++14",
+            "cppStandard": "gnu++17",
             "intelliSenseMode": "linux-gcc-x64"
         }
     ],


### PR DESCRIPTION
Qt 6 uses C++17 as default, so update the cppStandard to gnu++17