### PR TITLE
tasks: Add the tasks to build and run locally the production images

### DIFF
--- a/.github/workflows/build-ccpp.yaml
+++ b/.github/workflows/build-ccpp.yaml
@@ -42,4 +42,4 @@ jobs:
             false
 
           cd "${env:GITHUB_WORKSPACE}/${env:PROJECT_FOLDER}CITest"
-          ./.vscode/tasks.ps1 run build-container-torizon-${env:PROJECT_ARCH}
+          ./.vscode/tasks.ps1 run build-container-torizon-release-${env:PROJECT_ARCH}

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -38,4 +38,4 @@ jobs:
             false
 
           cd "${env:GITHUB_WORKSPACE}/${env:PROJECT_FOLDER}CITest"
-          ./.vscode/tasks.ps1 run build-container-torizon-${env:PROJECT_ARCH}
+          ./.vscode/tasks.ps1 run build-container-torizon-release-${env:PROJECT_ARCH}

--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -42,4 +42,4 @@ jobs:
             false
 
           cd "${env:GITHUB_WORKSPACE}/${env:PROJECT_FOLDER}CITest"
-          ./.vscode/tasks.ps1 run build-container-torizon-${env:PROJECT_ARCH}
+          ./.vscode/tasks.ps1 run build-container-torizon-release-${env:PROJECT_ARCH}

--- a/assets/tasks/common.json
+++ b/assets/tasks/common.json
@@ -1659,7 +1659,7 @@
             ],
             "problemMatcher": "$msCompile",
             "icon": {
-                "id": "flame",
+                "id": "run",
                 "color": "terminal.ansiYellow"
             }
         },
@@ -1693,7 +1693,7 @@
             ],
             "problemMatcher": "$msCompile",
             "icon": {
-                "id": "flame",
+                "id": "run",
                 "color": "terminal.ansiYellow"
             }
         },
@@ -1727,7 +1727,7 @@
             ],
             "problemMatcher": "$msCompile",
             "icon": {
-                "id": "flame",
+                "id": "run",
                 "color": "terminal.ansiYellow"
             }
         },
@@ -1761,7 +1761,7 @@
             ],
             "problemMatcher": "$msCompile",
             "icon": {
-                "id": "flame",
+                "id": "run",
                 "color": "terminal.ansiYellow"
             }
         },

--- a/assets/tasks/common.json
+++ b/assets/tasks/common.json
@@ -686,47 +686,6 @@
             }
         },
         {
-            "label": "build-container-torizon-arm64",
-            "detail": "",
-            "hide": true,
-            "command": "DOCKER_HOST=",
-            "type": "shell",
-            "options": {
-                "env": {
-                    "LOCAL_REGISTRY": "localhost",
-                    "TAG": "arm64",
-                    "GPU": "${config:torizon_gpu}",
-                    "SSH_DEBUG_PORT": "${config:torizon_debug_ssh_port}",
-                    "DEBUG_PORT": "${config:torizon_debug_port}",
-                    "DEBUG_PORT2": "${config:torizon_debug_port2}",
-                    "DEBUG_PORT3": "${config:torizon_debug_port3}"
-                }
-            },
-            "args": [
-                "docker",
-                "compose",
-                "build",
-                "--pull",
-                "--build-arg",
-                "SSHUSERNAME=${config:torizon_run_as}",
-                "--build-arg",
-                "APP_ROOT=${config:torizon_app_root}",
-                "--build-arg",
-                "IMAGE_ARCH=arm64",
-                "--build-arg",
-                "SSH_DEBUG_PORT=${config:torizon_debug_ssh_port}",
-                "--build-arg",
-                "GPU=${config:torizon_gpu}",
-                "__container__"
-            ],
-            "dependsOrder": "sequence",
-            "problemMatcher": "$msCompile",
-            "icon": {
-                "id": "flame",
-                "color": "terminal.ansiYellow"
-            }
-        },
-        {
             "label": "build-container-torizon-debug-arm64",
             "detail": "",
             "hide": true,
@@ -759,47 +718,6 @@
                 "--build-arg",
                 "GPU=${config:torizon_gpu}",
                 "__container__-debug"
-            ],
-            "dependsOrder": "sequence",
-            "problemMatcher": "$msCompile",
-            "icon": {
-                "id": "flame",
-                "color": "terminal.ansiYellow"
-            }
-        },
-        {
-            "label": "build-container-torizon-arm",
-            "detail": "",
-            "hide": true,
-            "command": "DOCKER_HOST=",
-            "type": "shell",
-            "options": {
-                "env": {
-                    "LOCAL_REGISTRY": "localhost",
-                    "TAG": "arm",
-                    "GPU": "${config:torizon_gpu}",
-                    "SSH_DEBUG_PORT": "${config:torizon_debug_ssh_port}",
-                    "DEBUG_PORT": "${config:torizon_debug_port}",
-                    "DEBUG_PORT2": "${config:torizon_debug_port2}",
-                    "DEBUG_PORT3": "${config:torizon_debug_port3}"
-                }
-            },
-            "args": [
-                "docker",
-                "compose",
-                "build",
-                "--pull",
-                "--build-arg",
-                "SSHUSERNAME=${config:torizon_run_as}",
-                "--build-arg",
-                "APP_ROOT=${config:torizon_app_root}",
-                "--build-arg",
-                "IMAGE_ARCH=arm",
-                "--build-arg",
-                "SSH_DEBUG_PORT=${config:torizon_debug_ssh_port}",
-                "--build-arg",
-                "GPU=${config:torizon_gpu}",
-                "__container__"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",
@@ -850,47 +768,6 @@
             }
         },
         {
-            "label": "build-container-torizon-amd64",
-            "detail": "",
-            "hide": true,
-            "command": "DOCKER_HOST=",
-            "type": "shell",
-            "options": {
-                "env": {
-                    "LOCAL_REGISTRY": "localhost",
-                    "TAG": "amd64",
-                    "GPU": "${config:torizon_gpu}",
-                    "SSH_DEBUG_PORT": "${config:torizon_debug_ssh_port}",
-                    "DEBUG_PORT": "${config:torizon_debug_port}",
-                    "DEBUG_PORT2": "${config:torizon_debug_port2}",
-                    "DEBUG_PORT3": "${config:torizon_debug_port3}"
-                }
-            },
-            "args": [
-                "docker",
-                "compose",
-                "build",
-                "--pull",
-                "--build-arg",
-                "SSHUSERNAME=${config:torizon_run_as}",
-                "--build-arg",
-                "APP_ROOT=${config:torizon_app_root}",
-                "--build-arg",
-                "IMAGE_ARCH=amd64",
-                "--build-arg",
-                "SSH_DEBUG_PORT=${config:torizon_debug_ssh_port}",
-                "--build-arg",
-                "GPU=${config:torizon_gpu}",
-                "__container__"
-            ],
-            "dependsOrder": "sequence",
-            "problemMatcher": "$msCompile",
-            "icon": {
-                "id": "flame",
-                "color": "terminal.ansiYellow"
-            }
-        },
-        {
             "label": "build-container-torizon-debug-amd64",
             "detail": "",
             "hide": true,
@@ -923,47 +800,6 @@
                 "--build-arg",
                 "GPU=${config:torizon_gpu}",
                 "__container__-debug"
-            ],
-            "dependsOrder": "sequence",
-            "problemMatcher": "$msCompile",
-            "icon": {
-                "id": "flame",
-                "color": "terminal.ansiYellow"
-            }
-        },
-        {
-            "label": "build-container-torizon-riscv64",
-            "detail": "",
-            "hide": true,
-            "command": "DOCKER_HOST=",
-            "type": "shell",
-            "options": {
-                "env": {
-                    "LOCAL_REGISTRY": "localhost",
-                    "TAG": "riscv64",
-                    "GPU": "${config:torizon_gpu}",
-                    "SSH_DEBUG_PORT": "${config:torizon_debug_ssh_port}",
-                    "DEBUG_PORT": "${config:torizon_debug_port}",
-                    "DEBUG_PORT2": "${config:torizon_debug_port2}",
-                    "DEBUG_PORT3": "${config:torizon_debug_port3}"
-                }
-            },
-            "args": [
-                "docker",
-                "compose",
-                "build",
-                "--pull",
-                "--build-arg",
-                "SSHUSERNAME=${config:torizon_run_as}",
-                "--build-arg",
-                "APP_ROOT=${config:torizon_app_root}",
-                "--build-arg",
-                "IMAGE_ARCH=riscv64",
-                "--build-arg",
-                "SSH_DEBUG_PORT=${config:torizon_debug_ssh_port}",
-                "--build-arg",
-                "GPU=${config:torizon_gpu}",
-                "__container__"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",
@@ -1434,134 +1270,31 @@
             }
         },
         {
-            "label": "push-release-arm",
-            "detail": "This task will build the application based in the\nproduction Dockerfile and push the image to DockerHub.",
-            "command": "DOCKER_HOST=",
-            "type": "shell",
-            "options": {
-                "env": {
-                    "DOCKER_LOGIN": "${input:dockerLogin}",
-                    "TAG": "arm"
-                }
-            },
-            "args": [
-                "docker",
-                "compose",
-                "push",
-                "__container__"
-            ],
-            "dependsOn": [
-                "docker-login",
-                "build-release-arm"
-            ],
-            "dependsOrder": "sequence",
-            "problemMatcher": "$msCompile",
-            "icon": {
-                "id": "repo-push",
-                "color": "terminal.ansiYellow"
-            }
-        },
-        {
-            "label": "push-release-arm64",
-            "detail": "This task will build the application based in the\nproduction Dockerfile and push the image to DockerHub.",
-            "command": "DOCKER_HOST=",
-            "type": "shell",
-            "options": {
-                "env": {
-                    "DOCKER_LOGIN": "${input:dockerLogin}",
-                    "TAG": "arm64"
-                }
-            },
-            "args": [
-                "docker",
-                "compose",
-                "push",
-                "__container__"
-            ],
-            "dependsOn": [
-                "docker-login",
-                "build-release-arm64"
-            ],
-            "dependsOrder": "sequence",
-            "problemMatcher": "$msCompile",
-            "icon": {
-                "id": "repo-push",
-                "color": "terminal.ansiYellow"
-            }
-        },
-        {
-            "label": "push-release-amd64",
-            "detail": "This task will build the application based in the\nproduction Dockerfile and push the image to DockerHub.",
-            "command": "DOCKER_HOST=",
-            "type": "shell",
-            "options": {
-                "env": {
-                    "DOCKER_LOGIN": "${input:dockerLogin}",
-                    "TAG": "amd64"
-                }
-            },
-            "args": [
-                "docker",
-                "compose",
-                "push",
-                "__container__"
-            ],
-            "dependsOn": [
-                "docker-login",
-                "build-release-amd64"
-            ],
-            "dependsOrder": "sequence",
-            "problemMatcher": "$msCompile",
-            "icon": {
-                "id": "repo-push",
-                "color": "terminal.ansiYellow"
-            }
-        },
-        {
-            "label": "build-release-arm",
+            "label": "build-container-torizon-release-arm64",
             "detail": "",
             "hide": true,
             "command": "DOCKER_HOST=",
             "type": "shell",
             "options": {
                 "env": {
-                    "DOCKER_LOGIN": "${input:dockerLogin}",
-                    "TAG": "arm"
+                    "DOCKER_LOGIN": "localhost:5002",
+                    "TAG": "arm64",
+                    "GPU": "${config:torizon_gpu}"
                 }
             },
             "args": [
                 "docker",
                 "compose",
                 "build",
+                "--pull",
                 "--build-arg",
-                "IMAGE_ARCH=arm",
-                "__container__"
-            ],
-            "dependsOrder": "sequence",
-            "problemMatcher": "$msCompile",
-            "icon": {
-                "id": "flame",
-                "color": "terminal.ansiYellow"
-            }
-        },
-        {
-            "label": "build-release-arm64",
-            "detail": "",
-            "hide": true,
-            "command": "DOCKER_HOST=",
-            "type": "shell",
-            "options": {
-                "env": {
-                    "DOCKER_LOGIN": "${input:dockerLogin}",
-                    "TAG": "arm64"
-                }
-            },
-            "args": [
-                "docker",
-                "compose",
-                "build",
+                "SSHUSERNAME=${config:torizon_run_as}",
+                "--build-arg",
+                "APP_ROOT=${config:torizon_app_root}",
                 "--build-arg",
                 "IMAGE_ARCH=arm64",
+                "--build-arg",
+                "GPU=${config:torizon_gpu}",
                 "__container__"
             ],
             "dependsOrder": "sequence",
@@ -1572,26 +1305,460 @@
             }
         },
         {
-            "label": "build-release-amd64",
+            "label": "build-container-torizon-release-arm",
             "detail": "",
             "hide": true,
             "command": "DOCKER_HOST=",
-            "type": "process",
+            "type": "shell",
             "options": {
                 "env": {
-                    "DOCKER_LOGIN": "${input:dockerLogin}",
-                    "TAG": "amd64"
+                    "DOCKER_LOGIN": "localhost:5002",
+                    "TAG": "arm",
+                    "GPU": "${config:torizon_gpu}"
                 }
             },
             "args": [
                 "docker",
                 "compose",
                 "build",
+                "--pull",
                 "--build-arg",
-                "IMAGE_ARCH=amd64",
+                "SSHUSERNAME=${config:torizon_run_as}",
+                "--build-arg",
+                "APP_ROOT=${config:torizon_app_root}",
+                "--build-arg",
+                "IMAGE_ARCH=arm",
+                "--build-arg",
+                "GPU=${config:torizon_gpu}",
                 "__container__"
             ],
             "dependsOrder": "sequence",
+            "problemMatcher": "$msCompile",
+            "icon": {
+                "id": "flame",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "build-container-torizon-release-amd64",
+            "detail": "",
+            "hide": true,
+            "command": "DOCKER_HOST=",
+            "type": "shell",
+            "options": {
+                "env": {
+                    "DOCKER_LOGIN": "localhost:5002",
+                    "TAG": "amd64",
+                    "GPU": "${config:torizon_gpu}"
+                }
+            },
+            "args": [
+                "docker",
+                "compose",
+                "build",
+                "--pull",
+                "--build-arg",
+                "SSHUSERNAME=${config:torizon_run_as}",
+                "--build-arg",
+                "APP_ROOT=${config:torizon_app_root}",
+                "--build-arg",
+                "IMAGE_ARCH=amd64",
+                "--build-arg",
+                "GPU=${config:torizon_gpu}",
+                "__container__"
+            ],
+            "dependsOrder": "sequence",
+            "problemMatcher": "$msCompile",
+            "icon": {
+                "id": "flame",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "build-container-torizon-release-riscv64",
+            "detail": "",
+            "hide": true,
+            "command": "DOCKER_HOST=",
+            "type": "shell",
+            "options": {
+                "env": {
+                    "DOCKER_LOGIN": "localhost:5002",
+                    "TAG": "riscv64",
+                    "GPU": "${config:torizon_gpu}"
+                }
+            },
+            "args": [
+                "docker",
+                "compose",
+                "build",
+                "--pull",
+                "--build-arg",
+                "SSHUSERNAME=${config:torizon_run_as}",
+                "--build-arg",
+                "APP_ROOT=${config:torizon_app_root}",
+                "--build-arg",
+                "IMAGE_ARCH=riscv64",
+                "--build-arg",
+                "GPU=${config:torizon_gpu}",
+                "__container__"
+            ],
+            "dependsOrder": "sequence",
+            "problemMatcher": "$msCompile",
+            "icon": {
+                "id": "flame",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "push-container-torizon-release-arm64",
+            "detail": "",
+            "hide": true,
+            "command": "DOCKER_HOST=",
+            "type": "shell",
+            "options": {
+                "env": {
+                    "DOCKER_LOGIN": "localhost:5002",
+                    "TAG": "arm64"
+                }
+            },
+            "args": [
+                "docker",
+                "compose",
+                "push",
+                "__container__"
+            ],
+            "dependsOn": [
+                "build-container-torizon-release-arm64"
+            ],
+            "dependsOrder": "sequence",
+            "problemMatcher": "$msCompile",
+            "icon": {
+                "id": "repo-push",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "push-container-torizon-release-arm",
+            "detail": "",
+            "hide": true,
+            "command": "DOCKER_HOST=",
+            "type": "shell",
+            "options": {
+                "env": {
+                    "DOCKER_LOGIN": "localhost:5002",
+                    "TAG": "arm"
+                }
+            },
+            "args": [
+                "docker",
+                "compose",
+                "push",
+                "__container__"
+            ],
+            "dependsOn": [
+                "build-container-torizon-release-arm"
+            ],
+            "dependsOrder": "sequence",
+            "problemMatcher": "$msCompile",
+            "icon": {
+                "id": "repo-push",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "push-container-torizon-release-amd64",
+            "detail": "",
+            "hide": true,
+            "command": "DOCKER_HOST=",
+            "type": "shell",
+            "options": {
+                "env": {
+                    "DOCKER_LOGIN": "localhost:5002",
+                    "TAG": "amd64"
+                }
+            },
+            "args": [
+                "docker",
+                "compose",
+                "push",
+                "__container__"
+            ],
+            "dependsOn": [
+                "build-container-torizon-release-amd64"
+            ],
+            "dependsOrder": "sequence",
+            "problemMatcher": "$msCompile",
+            "icon": {
+                "id": "repo-push",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "push-container-torizon-release-riscv64",
+            "detail": "",
+            "hide": true,
+            "command": "DOCKER_HOST=",
+            "type": "shell",
+            "options": {
+                "env": {
+                    "DOCKER_LOGIN": "localhost:5002",
+                    "TAG": "riscv64"
+                }
+            },
+            "args": [
+                "docker",
+                "compose",
+                "push",
+                "__container__"
+            ],
+            "dependsOn": [
+                "build-container-torizon-release-riscv64"
+            ],
+            "dependsOrder": "sequence",
+            "problemMatcher": "$msCompile",
+            "icon": {
+                "id": "repo-push",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "pull-container-torizon-release-arm64",
+            "detail": "",
+            "hide": true,
+            "command": "sshpass",
+            "type": "process",
+            "args": [
+                "-p",
+                "${config:torizon_psswd}",
+                "ssh",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "torizon@${config:torizon_ip}",
+                "DOCKER_LOGIN=${config:host_ip}:5002 TAG=arm64 docker-compose pull __container__"
+            ],
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "push-container-torizon-release-arm64"
+            ],
+            "problemMatcher": "$msCompile",
+            "icon": {
+                "id": "flame",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "pull-container-torizon-release-arm",
+            "detail": "",
+            "hide": true,
+            "command": "sshpass",
+            "type": "process",
+            "args": [
+                "-p",
+                "${config:torizon_psswd}",
+                "ssh",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "torizon@${config:torizon_ip}",
+                "DOCKER_LOGIN=${config:host_ip}:5002 TAG=arm docker-compose pull __container__"
+            ],
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "push-container-torizon-release-arm"
+            ],
+            "problemMatcher": "$msCompile",
+            "icon": {
+                "id": "flame",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "pull-container-torizon-release-amd64",
+            "detail": "",
+            "hide": true,
+            "command": "sshpass",
+            "type": "process",
+            "args": [
+                "-p",
+                "${config:torizon_psswd}",
+                "ssh",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "torizon@${config:torizon_ip}",
+                "DOCKER_LOGIN=${config:host_ip}:5002 TAG=amd64 docker-compose pull __container__"
+            ],
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "push-container-torizon-release-amd64"
+            ],
+            "problemMatcher": "$msCompile",
+            "icon": {
+                "id": "flame",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "pull-container-torizon-release-riscv64",
+            "detail": "",
+            "hide": true,
+            "command": "sshpass",
+            "type": "process",
+            "args": [
+                "-p",
+                "${config:torizon_psswd}",
+                "ssh",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "torizon@${config:torizon_ip}",
+                "DOCKER_LOGIN=${config:host_ip}:5002 TAG=riscv64 docker-compose pull __container__"
+            ],
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "push-container-torizon-release-riscv64"
+            ],
+            "problemMatcher": "$msCompile",
+            "icon": {
+                "id": "flame",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "run-container-torizon-release-arm64",
+            "detail": "This task will build the application based in the production Dockerfile, push it to the local registry (localhost:5002), pull it on the board and run it on the board, showing the result in the VSCode terminal",
+            "command": "sshpass",
+            "type": "process",
+            "args": [
+                "-p",
+                "${config:torizon_psswd}",
+                "ssh",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "torizon@${config:torizon_ip}",
+                "DOCKER_LOGIN=${config:host_ip}:5002 TAG=arm64 GPU=${config:torizon_gpu} docker-compose up __container__"
+            ],
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "validate-settings",
+                "validate-arch-arm64",
+                "apply-torizon-packages",
+                "copy-docker-compose",
+                "pre-cleanup-arm64",
+                "build-container-torizon-release-arm64",
+                "push-container-torizon-release-arm64",
+                "pull-container-torizon-release-arm64",
+                "wait-a-bit"
+            ],
+            "problemMatcher": "$msCompile",
+            "icon": {
+                "id": "flame",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "run-container-torizon-release-arm",
+            "detail": "This task will build the application based in the production Dockerfile, push it to the local registry (localhost:5002), pull it on the board and run it on the board, showing the result in the VSCode terminal",
+            "command": "sshpass",
+            "type": "process",
+            "args": [
+                "-p",
+                "${config:torizon_psswd}",
+                "ssh",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "torizon@${config:torizon_ip}",
+                "DOCKER_LOGIN=${config:host_ip}:5002 TAG=arm GPU=${config:torizon_gpu} docker-compose up __container__"
+            ],
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "validate-settings",
+                "validate-arch-arm",
+                "apply-torizon-packages",
+                "copy-docker-compose",
+                "pre-cleanup-arm",
+                "build-container-torizon-release-arm",
+                "push-container-torizon-release-arm",
+                "pull-container-torizon-release-arm",
+                "wait-a-bit"
+            ],
+            "problemMatcher": "$msCompile",
+            "icon": {
+                "id": "flame",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "run-container-torizon-release-amd64",
+            "detail": "This task will build the application based in the production Dockerfile, push it to the local registry (localhost:5002), pull it on the board and run it on the board, showing the result in the VSCode terminal",
+            "command": "sshpass",
+            "type": "process",
+            "args": [
+                "-p",
+                "${config:torizon_psswd}",
+                "ssh",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "torizon@${config:torizon_ip}",
+                "DOCKER_LOGIN=${config:host_ip}:5002 TAG=amd64 GPU=${config:torizon_gpu} docker-compose up __container__"
+            ],
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "validate-settings",
+                "validate-arch-amd64",
+                "apply-torizon-packages",
+                "copy-docker-compose",
+                "pre-cleanup-amd64",
+                "build-container-torizon-release-amd64",
+                "push-container-torizon-release-amd64",
+                "pull-container-torizon-release-amd64",
+                "wait-a-bit"
+            ],
+            "problemMatcher": "$msCompile",
+            "icon": {
+                "id": "flame",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "run-container-torizon-release-riscv64",
+            "detail": "This task will build the application based in the production Dockerfile, push it to the local registry (localhost:5002), pull it on the board and run it on the board, showing the result in the VSCode terminal",
+            "command": "sshpass",
+            "type": "process",
+            "args": [
+                "-p",
+                "${config:torizon_psswd}",
+                "ssh",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "torizon@${config:torizon_ip}",
+                "DOCKER_LOGIN=${config:host_ip}:5002 TAG=riscv64 GPU=${config:torizon_gpu} docker-compose up __container__"
+            ],
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "validate-settings",
+                "validate-arch-riscv64",
+                "apply-torizon-packages",
+                "copy-docker-compose",
+                "pre-cleanup-riscv64",
+                "build-container-torizon-release-riscv64",
+                "push-container-torizon-release-riscv64",
+                "pull-container-torizon-release-riscv64",
+                "wait-a-bit"
+            ],
             "problemMatcher": "$msCompile",
             "icon": {
                 "id": "flame",

--- a/cmakeConsole/.vscode/tasks.json
+++ b/cmakeConsole/.vscode/tasks.json
@@ -256,7 +256,7 @@
                 "$gcc"
             ],
             "icon": {
-                "id": "flame",
+                "id": "trash",
                 "color": "terminal.ansiYellow"
             }
         },
@@ -283,7 +283,7 @@
                 "$gcc"
             ],
             "icon": {
-                "id": "flame",
+                "id": "trash",
                 "color": "terminal.ansiYellow"
             },
             "dependsOrder": "sequence",
@@ -314,7 +314,7 @@
                 "$gcc"
             ],
             "icon": {
-                "id": "flame",
+                "id": "trash",
                 "color": "terminal.ansiYellow"
             },
             "dependsOrder": "sequence",


### PR DESCRIPTION
This commit adds the tasks to:
. Build the application based in the  production Dockerfile . Push it to the local registry (localhost:5002)
. Pull it on the board from the local registry
. And run it on the board, showing the result in the VSCode terminal