### PR TITLE
cppQML: tasks: Remove build <arch> for open-in-qt-cretor-<arch>

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -6,7 +6,7 @@ jobs:
   spell-check:
     runs-on: ubuntu-latest
     container:
-      image: node:16
+      image: node:18
     name: Spell Check
     steps:
       - uses: actions/checkout@v3

--- a/cppQML/.vscode/tasks.json
+++ b/cppQML/.vscode/tasks.json
@@ -78,7 +78,7 @@
             },
             "dependsOrder": "sequence",
             "dependsOn": [
-                "build-debug-arm64",
+                "build-debug-amd64-local",
                 "update-qt-ini-arm64"
             ]
         },
@@ -108,7 +108,7 @@
             },
             "dependsOrder": "sequence",
             "dependsOn": [
-                "build-debug-arm",
+                "build-debug-amd64-local",
                 "update-qt-ini-arm"
             ]
         },
@@ -138,7 +138,7 @@
             },
             "dependsOrder": "sequence",
             "dependsOn": [
-                "build-debug-amd64",
+                "build-debug-amd64-local",
                 "update-qt-ini-amd64"
             ]
         },


### PR DESCRIPTION
For the remote debug on the Qt Creator we should use the local build and the local kit. If we use the remote build we will have to configure the kit for each of the <arch>. Also the path should be the same as the local build instead of the container ones.