### PR TITLE
Bump version for cppSlint / rustSlint / dotnetAvalonia / dotnetAvaloniaFrameBuffer

### DIFF
--- a/cppSlint/Dockerfile
+++ b/cppSlint/Dockerfile
@@ -1,5 +1,5 @@
 ## using Slint v1.2.2 base images
-ARG CROSS_SDK_BASE_TAG=3.0.9-bookworm-1.2.2
+ARG CROSS_SDK_BASE_TAG=3.0.9-bookworm-1.3.0
 ARG BASE_VERSION=3.0.8
 ##
 # Board architecture

--- a/cppSlint/Dockerfile.debug
+++ b/cppSlint/Dockerfile.debug
@@ -10,7 +10,7 @@ ARG IMAGE_ARCH=
 # Base container version
 # Using the Slint v1.2.2 base images
 ##
-ARG BASE_VERSION=3.0.9-bookworm-1.2.2
+ARG BASE_VERSION=3.0.9-bookworm-1.3.0
 
 ##
 # Application Name

--- a/cppSlint/Dockerfile.sdk
+++ b/cppSlint/Dockerfile.sdk
@@ -1,7 +1,7 @@
 # ARGUMENTS --------------------------------------------------------------------
 ## Using the Slint v1.2.2 base images
-ARG CROSS_SDK_BASE_TAG=3.0.9-bookworm-1.2.2
-ARG BASE_VERSION=3.0.9-bookworm-1.2.2
+ARG CROSS_SDK_BASE_TAG=3.0.9-bookworm-1.3.0
+ARG BASE_VERSION=3.0.9-bookworm-1.3.0
 
 ARG IMAGE_ARCH=
 

--- a/dotnetAvalonia/__change__.csproj
+++ b/dotnetAvalonia/__change__.csproj
@@ -15,13 +15,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.2" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.0.2" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.2" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.2" />
+        <PackageReference Include="Avalonia" Version="11.0.5" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.0.5" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.5" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.5" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.2" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.2" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.5" />
+        <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.5" />
     </ItemGroup>
 
 </Project>

--- a/dotnetAvaloniaFrameBuffer/__change__.csproj
+++ b/dotnetAvaloniaFrameBuffer/__change__.csproj
@@ -16,15 +16,15 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.2" />
-        <PackageReference Include="Avalonia.Skia" Version="11.0.2" />
-        <PackageReference Include="Avalonia.LinuxFramebuffer" Version="11.0.2" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.0.2" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.2" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.2" />
+        <PackageReference Include="Avalonia" Version="11.0.5" />
+        <PackageReference Include="Avalonia.Skia" Version="11.0.5" />
+        <PackageReference Include="Avalonia.LinuxFramebuffer" Version="11.0.5" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.0.5" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.5" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.5" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.2" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.2" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.5" />
+        <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.5" />
     </ItemGroup>
 
 </Project>

--- a/rustSlint/Dockerfile
+++ b/rustSlint/Dockerfile
@@ -1,5 +1,5 @@
 ## Using Slint v1.2.2 base images
-ARG CROSS_SDK_BASE_TAG=3.0.9-bookworm-1.2.2
+ARG CROSS_SDK_BASE_TAG=3.0.9-bookworm-1.3.0
 ARG BASE_VERSION=3.0.8
 ##
 # Board architecture

--- a/rustSlint/Dockerfile.debug
+++ b/rustSlint/Dockerfile.debug
@@ -10,7 +10,7 @@ ARG IMAGE_ARCH=
 # Base container version
 # Using Slint v1.2.2 base images
 ##
-ARG BASE_VERSION=3.0.9-bookworm-1.2.2
+ARG BASE_VERSION=3.0.9-bookworm-1.3.0
 
 ##
 # Application Name

--- a/rustSlint/Dockerfile.sdk
+++ b/rustSlint/Dockerfile.sdk
@@ -1,7 +1,7 @@
 # ARGUMENTS --------------------------------------------------------------------
 ## Using Slint v1.1.1 base images
-ARG CROSS_SDK_BASE_TAG=3.0.9-bookworm-1.2.2
-ARG BASE_VERSION=3.0.9-bookworm-1.2.2
+ARG CROSS_SDK_BASE_TAG=3.0.9-bookworm-1.3.0
+ARG BASE_VERSION=3.0.9-bookworm-1.3.0
 
 ARG IMAGE_ARCH=
 


### PR DESCRIPTION
Maintenance work for release the `v2.3.0` of the templates.