### PR TITLE
cppConsole and cConsole: Fix clean tasks

### DIFF
--- a/cConsole/.vscode/tasks.json
+++ b/cConsole/.vscode/tasks.json
@@ -33,7 +33,10 @@
             "icon": {
                 "id": "flame",
                 "color": "terminal.ansiYellow"
-            }
+            },
+            "dependsOn": [
+                "build-container-image-sdk-amd64"
+            ]
         },
         {
             "label": "build-makedir-arm",
@@ -50,7 +53,10 @@
             "icon": {
                 "id": "flame",
                 "color": "terminal.ansiYellow"
-            }
+            },
+            "dependsOn": [
+                "build-container-image-sdk-arm"
+            ]
         },
         {
             "label": "build-makedir-arm64",
@@ -67,7 +73,10 @@
             "icon": {
                 "id": "flame",
                 "color": "terminal.ansiYellow"
-            }
+            },
+            "dependsOn": [
+                "build-container-image-sdk-arm64"
+            ]
         },
         {
             "label": "build-makedir-riscv64",
@@ -84,7 +93,10 @@
             "icon": {
                 "id": "flame",
                 "color": "terminal.ansiYellow"
-            }
+            },
+            "dependsOn": [
+                "build-container-image-sdk-riscv64"
+            ]
         },
         {
             "label": "build-debug-amd64-local",
@@ -106,22 +118,6 @@
             "dependsOn": [
                 "build-makedir-amd64-local"
             ]
-        },
-        {
-            "label": "clean",
-            "detail": "Clean the application build directory. `make clean`",
-            "command": "make",
-            "type": "shell",
-            "args": [
-                "clean"
-            ],
-            "problemMatcher": [
-                "$gcc"
-            ],
-            "icon": {
-                "id": "flame",
-                "color": "terminal.ansiYellow"
-            }
         },
         {
             "label": "build-debug-arm64",
@@ -150,7 +146,7 @@
             },
             "dependsOrder": "sequence",
             "dependsOn": [
-                "build-container-image-sdk-arm64"
+                "build-makedir-arm64"
             ]
         },
         {
@@ -221,7 +217,7 @@
             },
             "dependsOrder": "sequence",
             "dependsOn": [
-                "build-container-image-sdk-arm"
+                "build-makedir-arm"
             ]
         },
         {
@@ -292,7 +288,7 @@
             },
             "dependsOrder": "sequence",
             "dependsOn": [
-                "build-container-image-sdk-amd64"
+                "build-makedir-amd64"
             ]
         },
         {
@@ -363,7 +359,7 @@
             },
             "dependsOrder": "sequence",
             "dependsOn": [
-                "build-container-image-sdk-riscv64"
+                "build-makedir-riscv64"
             ]
         },
         {
@@ -406,6 +402,120 @@
                 "id": "flame",
                 "color": "terminal.ansiYellow"
             }
+        },
+        {
+            "label": "clean-arm64",
+            "detail": "Clean the application build directory. `make clean`",
+            "command": "make",
+            "type": "shell",
+            "args": [
+                "clean",
+                "ARCH=x86_64"
+            ],
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "icon": {
+                "id": "flame",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "clean-local",
+            "detail": "Clean the local application build directory. `make clean`",
+            "command": "make",
+            "type": "shell",
+            "args": [
+                "clean",
+                "ARCH=x86_64"
+            ],
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "icon": {
+                "id": "trash",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "clean-arm64",
+            "detail": "Clean the arm64 application build directory. `make clean`",
+            "command": "make",
+            "type": "shell",
+            "args": [
+                "clean",
+                "ARCH=aarch64"
+            ],
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "icon": {
+                "id": "trash",
+                "color": "terminal.ansiYellow"
+            },
+            "dependsOrder": "sequence",
+            "dependsOn": [
+            ]
+        },
+        {
+            "label": "clean-arm",
+            "detail": "Clean the arm application build directory. `make clean`",
+            "command": "make",
+            "type": "shell",
+            "args": [
+                "clean",
+                "ARCH=armhf"
+            ],
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "icon": {
+                "id": "trash",
+                "color": "terminal.ansiYellow"
+            },
+            "dependsOrder": "sequence",
+            "dependsOn": [
+            ]
+        },
+        {
+            "label": "clean-amd64",
+            "detail": "Clean the amd64 application build directory. `make clean`",
+            "command": "make",
+            "type": "shell",
+            "args": [
+                "clean",
+                "ARCH=amd64"
+            ],
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "icon": {
+                "id": "trash",
+                "color": "terminal.ansiYellow"
+            },
+            "dependsOrder": "sequence",
+            "dependsOn": [
+            ]
+        },
+        {
+            "label": "clean-riscv64",
+            "detail": "Clean the riscv64 application build directory. `make clean`",
+            "command": "make",
+            "type": "shell",
+            "args": [
+                "clean",
+                "ARCH=riscv64"
+            ],
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "icon": {
+                "id": "trash",
+                "color": "terminal.ansiYellow"
+            },
+            "dependsOrder": "sequence",
+            "dependsOn": [
+            ]
         },
     ],
 "inputs": []

--- a/cppConsole/.vscode/tasks.json
+++ b/cppConsole/.vscode/tasks.json
@@ -33,7 +33,10 @@
             "icon": {
                 "id": "flame",
                 "color": "terminal.ansiYellow"
-            }
+            },
+            "dependsOn": [
+                "build-container-image-sdk-amd64"
+            ]
         },
         {
             "label": "build-makedir-arm",
@@ -50,7 +53,10 @@
             "icon": {
                 "id": "flame",
                 "color": "terminal.ansiYellow"
-            }
+            },
+            "dependsOn": [
+                "build-container-image-sdk-arm"
+            ]
         },
         {
             "label": "build-makedir-arm64",
@@ -67,7 +73,10 @@
             "icon": {
                 "id": "flame",
                 "color": "terminal.ansiYellow"
-            }
+            },
+            "dependsOn": [
+                "build-container-image-sdk-arm64"
+            ]
         },
         {
             "label": "build-makedir-riscv64",
@@ -83,8 +92,11 @@
             ],
             "icon": {
                 "id": "flame",
-                "color": "terminal.ansiYellow"
-            }
+                "color": "terminal.ansiYellow",
+            },
+            "dependsOn": [
+                "build-container-image-sdk-riscv64"
+            ]
         },
         {
             "label": "build-debug-amd64-local",
@@ -106,22 +118,6 @@
             "dependsOn": [
                 "build-makedir-amd64-local"
             ]
-        },
-        {
-            "label": "clean",
-            "detail": "Clean the application build directory. `make clean`",
-            "command": "make",
-            "type": "shell",
-            "args": [
-                "clean"
-            ],
-            "problemMatcher": [
-                "$gcc"
-            ],
-            "icon": {
-                "id": "flame",
-                "color": "terminal.ansiYellow"
-            }
         },
         {
             "label": "build-debug-arm64",
@@ -150,7 +146,7 @@
             },
             "dependsOrder": "sequence",
             "dependsOn": [
-                "build-container-image-sdk-arm64"
+                "build-makedir-arm64"
             ]
         },
         {
@@ -221,7 +217,7 @@
             },
             "dependsOrder": "sequence",
             "dependsOn": [
-                "build-container-image-sdk-arm"
+                "build-makedir-arm"
             ]
         },
         {
@@ -292,7 +288,7 @@
             },
             "dependsOrder": "sequence",
             "dependsOn": [
-                "build-container-image-sdk-amd64"
+                "build-makedir-amd64"
             ]
         },
         {
@@ -363,7 +359,7 @@
             },
             "dependsOrder": "sequence",
             "dependsOn": [
-                "build-container-image-sdk-riscv64"
+                "build-makedir-riscv64"
             ]
         },
         {
@@ -406,6 +402,120 @@
                 "id": "flame",
                 "color": "terminal.ansiYellow"
             }
+        },
+        {
+            "label": "clean-arm64",
+            "detail": "Clean the application build directory. `make clean`",
+            "command": "make",
+            "type": "shell",
+            "args": [
+                "clean",
+                "ARCH=x86_64"
+            ],
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "icon": {
+                "id": "flame",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "clean-local",
+            "detail": "Clean the local application build directory. `make clean`",
+            "command": "make",
+            "type": "shell",
+            "args": [
+                "clean",
+                "ARCH=x86_64"
+            ],
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "icon": {
+                "id": "trash",
+                "color": "terminal.ansiYellow"
+            }
+        },
+        {
+            "label": "clean-arm64",
+            "detail": "Clean the arm64 application build directory. `make clean`",
+            "command": "make",
+            "type": "shell",
+            "args": [
+                "clean",
+                "ARCH=aarch64"
+            ],
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "icon": {
+                "id": "trash",
+                "color": "terminal.ansiYellow"
+            },
+            "dependsOrder": "sequence",
+            "dependsOn": [
+            ]
+        },
+        {
+            "label": "clean-arm",
+            "detail": "Clean the arm application build directory. `make clean`",
+            "command": "make",
+            "type": "shell",
+            "args": [
+                "clean",
+                "ARCH=armhf"
+            ],
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "icon": {
+                "id": "trash",
+                "color": "terminal.ansiYellow"
+            },
+            "dependsOrder": "sequence",
+            "dependsOn": [
+            ]
+        },
+        {
+            "label": "clean-amd64",
+            "detail": "Clean the amd64 application build directory. `make clean`",
+            "command": "make",
+            "type": "shell",
+            "args": [
+                "clean",
+                "ARCH=amd64"
+            ],
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "icon": {
+                "id": "trash",
+                "color": "terminal.ansiYellow"
+            },
+            "dependsOrder": "sequence",
+            "dependsOn": [
+            ]
+        },
+        {
+            "label": "clean-riscv64",
+            "detail": "Clean the riscv64 application build directory. `make clean`",
+            "command": "make",
+            "type": "shell",
+            "args": [
+                "clean",
+                "ARCH=riscv64"
+            ],
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "icon": {
+                "id": "trash",
+                "color": "terminal.ansiYellow"
+            },
+            "dependsOrder": "sequence",
+            "dependsOn": [
+            ]
         },
     ],
 "inputs": []


### PR DESCRIPTION
Fix clean tasks that were not cleaning the build directory, and add the build-makedir-<arch> task in the dependsOn of the build-debug-<arch> tasks.