### PR TITLE
python3: Fix and improve pip install on host and containers

### DIFF
--- a/python3Console/.doc/README.md
+++ b/python3Console/.doc/README.md
@@ -15,7 +15,10 @@ The deployable package is then copied into the running debug container using **s
 
 Remote debugging is performed by running **debugpy** inside the running container on the device, in a task named **start-torizon-debug\${architecture}**, and then attaching to this running container, as described at [VSCode Python remote debugging](https://code.visualstudio.com/docs/python/debugging#_remote-script-debugging-with-ssh). For local debugging, the method used is the one described in the [VSCode documentation for Python Debugging](https://code.visualstudio.com/docs/python/debugging) is used. The tasks that perform the debugging are those present in the **launch.json** file.
 
-The dependencies of the project that should be installed using **pip** should be defined on the **requirements-debug.txt** file (remote Debug image and local host dependencies) and on the **requirements-release.txt** file (remote Release image dependencies). 
+The python packages of the project that should be installed using **pip** should be defined on:
+- **requirements-local.txt** file for host/local debugging packages
+- **requirements-debug.txt** file for remote debugging image package (installed on **Dockerfile.debug** file)
+- **requirements-release.txt** file for production (release) image packages (installed on **Dockerfile** file)
 
 The source code of the template is a simple Hello World (Hello Torizon, actually) in Python.
 
@@ -27,17 +30,14 @@ How to create a virtual environment on this template:
 
       `python -m venv .venv --system-site-packages`
 
-      If you do not want to use Python packages installed with **apt** on your host remove the **--system-site-packages** argument. In this case, you have to include **debugpy** on the **requirements-debug.txt** file.
+      If you do not want to use Python packages installed with **apt** on your host remove the **--system-site-packages** argument.
 
  - Press **F1**
  - Select the command **Python: Select Interpreter**
- - Select the Python interpreter of your **.venv** 
+ - Select the Python interpreter of your **.venv**
  - If it doesn't select the Python from the venv, press F1 and select the command
  **Developer: Reload Window**)
 
-To install a Python package on the venv (and also on the Debug image), put it 
-on the **requirements-debug.txt** file (to install it on the Release image put it
-on the **requirements.release.txt** file)
 
 For more details, please watch the demonstration video below:
 

--- a/python3Console/.vscode/tasks.json
+++ b/python3Console/.vscode/tasks.json
@@ -9,7 +9,7 @@
             "type": "process",
             "args": [
                 "4",
-            ],            
+            ],
             "dependsOn": [
                 "validate-settings",
                 "validate-arch-arm",
@@ -62,7 +62,7 @@
             "type": "process",
             "args": [
                 "4",
-            ],            
+            ],
             "dependsOn": [
                 "validate-settings",
                 "validate-arch-arm64",
@@ -117,9 +117,8 @@
                 "-m",
                 "pip",
                 "install",
-                "--break-system-packages",
                 "-r",
-                "requirements-debug.txt"
+                "requirements-local.txt"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",

--- a/python3Console/Dockerfile
+++ b/python3Console/Dockerfile
@@ -40,11 +40,11 @@ RUN python3 -m venv ${APP_ROOT}/.venv --system-site-packages
 # Install pip packages on venv
 COPY requirements-release.txt /requirements-release.txt
 RUN . ${APP_ROOT}/.venv/bin/activate && \
-    pip3 install --upgrade pip && pip3 install --break-system-packages -r requirements-release.txt && \
+    pip3 install --upgrade pip && pip3 install -r requirements-release.txt && \
     rm requirements-release.txt
 
-# Copy the application source code in the workspace to the $APP_ROOT directory 
-# path inside the container, where $APP_ROOT is the torizon_app_root 
+# Copy the application source code in the workspace to the $APP_ROOT directory
+# path inside the container, where $APP_ROOT is the torizon_app_root
 # configuration defined in settings.json
 COPY ./src ${APP_ROOT}/src
 
@@ -53,4 +53,3 @@ WORKDIR ${APP_ROOT}
 ENV APP_ROOT=${APP_ROOT}
 # Activate and run the code
 CMD . ${APP_ROOT}/.venv/bin/activate && python3 src/main.py --no-sandbox
-

--- a/python3Console/Dockerfile.debug
+++ b/python3Console/Dockerfile.debug
@@ -53,7 +53,6 @@ RUN apt-get -q -y update && \
     python3-pip \
     python3-setuptools \
     python3-venv \
-    python3-debugpy \
     && apt-get clean && apt-get autoremove && \
     rm -rf /var/lib/apt/lists/*
 
@@ -74,7 +73,7 @@ RUN python3 -m venv ${APP_ROOT}/.venv --system-site-packages
 # Install pip packages on venv
 COPY requirements-debug.txt /requirements-debug.txt
 RUN . ${APP_ROOT}/.venv/bin/activate && \
-    pip3 install --upgrade pip && pip3 install --break-system-packages -r requirements-debug.txt && \
+    pip3 install --upgrade pip && pip3 install -r requirements-debug.txt && \
     rm requirements-debug.txt
 
 # ⚠️ DEBUG PURPOSES ONLY!!
@@ -99,8 +98,8 @@ RUN mkdir /var/run/sshd && \
 RUN rm -r /etc/ssh/ssh*key && \
     dpkg-reconfigure openssh-server
 
-# Copy the application source code in the workspace to the $APP_ROOT directory 
-# path inside the container, where $APP_ROOT is the torizon_app_root 
+# Copy the application source code in the workspace to the $APP_ROOT directory
+# path inside the container, where $APP_ROOT is the torizon_app_root
 # configuration defined in settings.json
 COPY --chown=$SSHUSERNAME:$SSHUSERNAME ./src ${APP_ROOT}/src
 

--- a/python3Console/requirements-local.txt
+++ b/python3Console/requirements-local.txt
@@ -1,0 +1,1 @@
+debugpy

--- a/python3Pyside2QML/.doc/README.md
+++ b/python3Pyside2QML/.doc/README.md
@@ -15,7 +15,12 @@ The deployable package is then copied into the running debug container using **s
 
 Remote debugging is performed by running **debugpy** inside the running container on the device, in a task named **start-torizon-debug\${architecture}**, and then attaching to this running container, as described at [VSCode Python remote debugging](https://code.visualstudio.com/docs/python/debugging#_remote-script-debugging-with-ssh). For local debugging, the method used is the one described in the [VSCode documentation for Python Debugging](https://code.visualstudio.com/docs/python/debugging) is used. The tasks that perform the debugging are those present in the **launch.json** file.
 
-The dependencies of the project that should be installed using **pip** should be defined on the **requirements-debug.txt** file (remote Debug image and local host dependencies) and on the **requirements-release.txt** file (remote Release image dependencies). 
+The python packages of the project that should be installed using **pip** should be defined on:
+- **requirements-local.txt** file for host/local debugging packages
+- **requirements-debug.txt** file for remote debugging image package (installed on **Dockerfile.debug** file)
+- **requirements-release.txt** file for production (release) image packages (installed on **Dockerfile** file)
+
+The source code of the template is a simple Hello World (Hello Torizon, actually) in Python.
 
 ## Create a Python Virtual Environment
 
@@ -25,17 +30,14 @@ How to create a virtual environment on this template:
 
       `python -m venv .venv --system-site-packages`
 
-      If you do not want to use Python packages installed with **apt** on your host remove the **--system-site-packages** argument. In this case, you have to include **debugpy** on the **requirements-debug.txt** file.
+      If you do not want to use Python packages installed with **apt** on your host remove the **--system-site-packages** argument.
 
  - Press **F1**
  - Select the command **Python: Select Interpreter**
- - Select the Python interpreter of your **.venv** 
+ - Select the Python interpreter of your **.venv**
  - If it doesn't select the Python from the venv, press F1 and select the command
  **Developer: Reload Window**)
 
-To install a Python package on the venv (and also on the Debug image), put it 
-on the **requirements-debug.txt** file (to install it on the Release image put it
-on the **requirements.release.txt** file)
 
 For more details, please watch the demonstration video below:
 

--- a/python3Pyside2QML/.vscode/tasks.json
+++ b/python3Pyside2QML/.vscode/tasks.json
@@ -9,7 +9,7 @@
             "type": "process",
             "args": [
                 "4",
-            ],            
+            ],
             "dependsOn": [
                 "validate-settings",
                 "validate-arch-arm",
@@ -62,7 +62,7 @@
             "type": "process",
             "args": [
                 "4",
-            ],            
+            ],
             "dependsOn": [
                 "validate-settings",
                 "validate-arch-arm64",
@@ -117,9 +117,8 @@
                 "-m",
                 "pip",
                 "install",
-                "--break-system-packages",
                 "-r",
-                "requirements-debug.txt"
+                "requirements-local.txt"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",

--- a/python3Pyside2QML/Dockerfile
+++ b/python3Pyside2QML/Dockerfile
@@ -71,13 +71,13 @@ RUN python3 -m venv ${APP_ROOT}/.venv --system-site-packages
 # Install pip packages on venv
 COPY requirements-release.txt /requirements-release.txt
 RUN . ${APP_ROOT}/.venv/bin/activate && \
-    pip3 install --upgrade pip && pip3 install --break-system-packages -r requirements-release.txt && \
+    pip3 install --upgrade pip && pip3 install -r requirements-release.txt && \
     rm requirements-release.txt
 
 USER torizon
 
-# Copy the application source code in the workspace to the $APP_ROOT directory 
-# path inside the container, where $APP_ROOT is the torizon_app_root 
+# Copy the application source code in the workspace to the $APP_ROOT directory
+# path inside the container, where $APP_ROOT is the torizon_app_root
 # configuration defined in settings.json
 COPY ./src ${APP_ROOT}/src
 

--- a/python3Pyside2QML/Dockerfile.debug
+++ b/python3Pyside2QML/Dockerfile.debug
@@ -74,7 +74,6 @@ RUN apt-get -q -y update && \
     python3-pip \
     python3-setuptools \
     python3-venv \
-    python3-debugpy \
     qml-module-qtquick-controls \
     qml-module-qtquick-controls2 \
     qml-module-qtquick2 \
@@ -106,7 +105,7 @@ RUN python3 -m venv ${APP_ROOT}/.venv --system-site-packages
 # Install pip packages on venv
 COPY requirements-debug.txt /requirements-debug.txt
 RUN . ${APP_ROOT}/.venv/bin/activate && \
-    pip3 install --upgrade pip && pip3 install --break-system-packages -r requirements-debug.txt && \
+    pip3 install --upgrade pip && pip3 install -r requirements-debug.txt && \
     rm requirements-debug.txt
 
 # ⚠️ DEBUG PURPOSES ONLY!!
@@ -131,8 +130,8 @@ RUN mkdir /var/run/sshd && \
 RUN rm -r /etc/ssh/ssh*key && \
     dpkg-reconfigure openssh-server
 
-# Copy the application source code in the workspace to the $APP_ROOT directory 
-# path inside the container, where $APP_ROOT is the torizon_app_root 
+# Copy the application source code in the workspace to the $APP_ROOT directory
+# path inside the container, where $APP_ROOT is the torizon_app_root
 # configuration defined in settings.json
 COPY --chown=$SSHUSERNAME:$SSHUSERNAME ./src ${APP_ROOT}/src
 

--- a/python3Pyside2QML/requirements-local.txt
+++ b/python3Pyside2QML/requirements-local.txt
@@ -1,0 +1,1 @@
+debugpy


### PR DESCRIPTION
Remove --system-break-packages from pip install and add requirements-local.txt to separate the host pip dependencies from the debug container ones (requirements-debug.txt).