### PR TITLE
dotnet-sdk-*: Enforce Microsoft source preference on install SDK script

### DIFF
--- a/scripts/installDepsScripts/installDotnetSDK6.sh
+++ b/scripts/installDepsScripts/installDotnetSDK6.sh
@@ -26,15 +26,23 @@ if [ "$source" != "https://packages.microsoft.com/ubuntu/$repo_version/prod" ]; 
     rm packages-microsoft-prod.deb
 
     # Remove the dotnet-sdk installation that doesn't come from the Microsoft source
-    sudo apt-get remove $package -y
+    sudo apt-get remove --purge $package -y
 
     sudo apt-get autoremove -y
+
+    # Enforce the preference for the dotnet and aspnet packages comming from the Microsoft source
+    if [ ! -f /etc/apt/preferences ] || ! grep -q "Package: dotnet\* aspnet\* netstandard\*" /etc/apt/preferences
+    then
+        echo "Package: dotnet* aspnet* netstandard*" | sudo tee -a /etc/apt/preferences
+        echo "Pin: origin packages.microsoft.com" | sudo tee -a /etc/apt/preferences
+        echo "Pin-Priority: 1001" | sudo tee -a /etc/apt/preferences
+
+    fi
 
 fi
 
 # Update packages
-sudo apt update -y
-
+sudo apt-get update -y
 
 # Install the dotnet-sdk that come from the Microsoft source
 sudo apt-get install $package -y

--- a/scripts/installDepsScripts/installDotnetSDK7.sh
+++ b/scripts/installDepsScripts/installDotnetSDK7.sh
@@ -26,14 +26,23 @@ if [ "$source" != "https://packages.microsoft.com/ubuntu/$repo_version/prod" ]; 
     rm packages-microsoft-prod.deb
 
     # Remove the dotnet-sdk installation that doesn't come from the Microsoft source
-    sudo apt-get remove $package -y
+    sudo apt-get remove --purge $package -y
 
     sudo apt-get autoremove -y
+
+    # Enforce the preference for the dotnet and aspnet packages comming from the Microsoft source
+    if [ ! -f /etc/apt/preferences ] || ! grep -q "Package: dotnet\* aspnet\* netstandard\*" /etc/apt/preferences
+    then
+        echo "Package: dotnet* aspnet* netstandard*" | sudo tee -a /etc/apt/preferences
+        echo "Pin: origin packages.microsoft.com" | sudo tee -a /etc/apt/preferences
+        echo "Pin-Priority: 1001" | sudo tee -a /etc/apt/preferences
+
+    fi
 
 fi
 
 # Update packages
-sudo apt update -y
+sudo apt-get update -y
 
 # Install the dotnet-sdk that come from the Microsoft source
 sudo apt-get install $package -y

--- a/scripts/installDepsScripts/installDotnetSDK8.sh
+++ b/scripts/installDepsScripts/installDotnetSDK8.sh
@@ -26,14 +26,23 @@ if [ "$source" != "https://packages.microsoft.com/ubuntu/$repo_version/prod" ]; 
     rm packages-microsoft-prod.deb
 
     # Remove the dotnet-sdk installation that doesn't come from the Microsoft source
-    sudo apt-get remove $package -y
+    sudo apt-get remove --purge $package -y
 
     sudo apt-get autoremove -y
+
+    # Enforce the preference for the dotnet and aspnet packages comming from the Microsoft source
+    if [ ! -f /etc/apt/preferences ] || ! grep -q "Package: dotnet\* aspnet\* netstandard\*" /etc/apt/preferences
+    then
+        echo "Package: dotnet* aspnet* netstandard*" | sudo tee -a /etc/apt/preferences
+        echo "Pin: origin packages.microsoft.com" | sudo tee -a /etc/apt/preferences
+        echo "Pin-Priority: 1001" | sudo tee -a /etc/apt/preferences
+
+    fi
 
 fi
 
 # Update packages
-sudo apt update -y
+sudo apt-get update -y
 
 # Install the dotnet-sdk that come from the Microsoft source
 sudo apt-get install $package -y


### PR DESCRIPTION
Enforce the preference for the dotnet and aspnet packages comming from
the Microsoft source, to ensure the correct installation of this packages
Links: https://github.com/dotnet/sdk/issues/27129#issuecomment-1214358108
https://learn.microsoft.com/en-us/dotnet/core/install/linux-package-mixup?pivots=os-linux-ubuntu#i-need-a-version-of-net-that-isnt-provided-by-my-linux-distribution