### PR TITLE
rust: On deps installation script, remove Rust installed through apt

### DIFF
--- a/scripts/installDepsScripts/installRustDeps.sh
+++ b/scripts/installDepsScripts/installRustDeps.sh
@@ -14,6 +14,12 @@ if [[ $is_rustup_default ]]; then
     rustup update
 
 else
+
+    # Remove the Rust installation comming from apt instead of rustup
+    sleep 1
+    sudo apt remove rust-all rustc rust-lldb rust-gdb cargo -y
+    sudo apt autoremove -y
+
     # Run script to install Rust and it's dependencies, based on the official
     # recommended method of installation
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh


### PR DESCRIPTION
When trying to install Rust through rustup, with the Rust packages installed through apt present, the following message is shown:

info: downloading installer
warning: it looks like you have an existing installation of Rust at:
warning: /usr/bin
warning: It is recommended that rustup be the primary Rust installation.
warning: Otherwise you may have confusion unless you are careful with your PATH
warning: If you are sure that you want both rustup and your already installed Rust
warning: then please reply `y' or `yes' or set RUSTUP_INIT_SKIP_PATH_CHECK to yes
warning: or pass `-y' to ignore all ignorable checks.
error: cannot install while Rust is installed

Continue? (y/N)

So it is better to remove the ones installed through apt before installing the ones through rustup.