### PR TITLE
scripts: add "-Ordered" Flag to ConvertFrom-Yaml

### DIFF
--- a/scripts/createDockerComposeMultiProduction.ps1
+++ b/scripts/createDockerComposeMultiProduction.ps1
@@ -39,7 +39,7 @@ foreach ($project in $codeWorkspace.folders) {
         "Reading $path/docker-compose.prod.yml"
 
         $yamlFile = Get-Content ("$path/docker-compose.prod.yml") | Out-String
-        $yamlObj = ConvertFrom-Yaml $yamlFile -AllDocuments
+        $yamlObj = ConvertFrom-Yaml $yamlFile -AllDocuments -Ordered
 
         if ($null -eq $retYaml) {
             $retYaml = $yamlObj

--- a/scripts/createDockerComposeProduction.ps1
+++ b/scripts/createDockerComposeProduction.ps1
@@ -166,7 +166,7 @@ Write-Host -ForegroundColor DarkGreen "✅ powershell-yaml loaded"
 # read the yaml file
 Write-Host "Reading docker-compose.yml file ..."
 $composeContent = Get-Content ("$compoFilePath/docker-compose.yml") | Out-String
-$composeLoad = ConvertFrom-Yaml $composeContent -AllDocuments
+$composeLoad = ConvertFrom-Yaml $composeContent -AllDocuments -Ordered
 $composeServices = $composeLoad.Services
 $removeKeys = New-Object Collections.Generic.List[String]
 $prodKeys = New-Object Collections.Generic.List[String]


### PR DESCRIPTION
this keeps the  `docker-compose.prod.yml` from getting scrambled up on every write