### PR TITLE
torizonPackages:Separate buildDeps from devDeps(renamed to devRuntime…

### DIFF
--- a/.github/workflows/build-ccpp.yaml
+++ b/.github/workflows/build-ccpp.yaml
@@ -15,12 +15,11 @@ jobs:
         project:
           - folder: cppQML
             container: cpp-qml
-            arch: arm64
+            vendor: "{ arch: 'arm64', torizon_arch: 'aarch64' }"
 
           - folder: cppSlint
             container: cpp-slint
-            arch: arm64
-
+            vendor: "{ arch: 'arm64', torizon_arch: 'aarch64' }"
 
     steps:
       - uses: actions/checkout@v3
@@ -30,10 +29,14 @@ jobs:
         env:
           PROJECT_FOLDER: ${{ matrix.project.folder }}
           PROJECT_CONTAINER: ${{ matrix.project.container }}
-          PROJECT_ARCH: ${{ matrix.project.arch }}
+          VENDOR: ${{ matrix.project.vendor }}
           DOCKER_LOGIN: localhost:5002
 
         run: |
+          $_vendor = ($env:VENDOR | ConvertFrom-Json)
+          $env:TORIZON_ARCH = $_vendor.torizon_arch
+          $env:PROJECT_ARCH = $_vendor.arch
+
           docker run --rm --privileged torizon/binfmt
 
           scripts/createFromTemplate.ps1 `
@@ -46,4 +49,9 @@ jobs:
             false
 
           cd "${env:GITHUB_WORKSPACE}/${env:PROJECT_FOLDER}CITest"
+
+          $_settingsJson = Get-Content -Path ".vscode/settings.json" | ConvertFrom-Json
+          $_settingsJson.torizon_arch = $env:TORIZON_ARCH
+          Set-Content -Path ".vscode/settings.json" -Value ($_settingsJson | ConvertTo-Json) -Encoding UTF8
+
           ./.vscode/tasks.ps1 run build-container-torizon-release-${env:PROJECT_ARCH}

--- a/.github/workflows/build-debug-ccpp.yaml
+++ b/.github/workflows/build-debug-ccpp.yaml
@@ -15,24 +15,28 @@ jobs:
         project:
           - folder: cppQML
             container: cpp-qml
-            arch: arm64
+            vendor: "{ arch: 'arm64', torizon_arch: 'aarch64' }"
 
           - folder: cppSlint
             container: cpp-slint
-            arch: arm64
-
+            vendor: "{ arch: 'arm64', torizon_arch: 'aarch64' }"
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build ${{ matrix.project.folder }} Dockerfile.debug
+      - name: Build ${{ matrix.project.folder }} Dockerfile
         shell: pwsh
         env:
           PROJECT_FOLDER: ${{ matrix.project.folder }}
           PROJECT_CONTAINER: ${{ matrix.project.container }}
-          PROJECT_ARCH: ${{ matrix.project.arch }}
+          VENDOR: ${{ matrix.project.vendor }}
+          DOCKER_LOGIN: localhost:5002
 
         run: |
+          $_vendor = ($env:VENDOR | ConvertFrom-Json)
+          $env:TORIZON_ARCH = $_vendor.torizon_arch
+          $env:PROJECT_ARCH = $_vendor.arch
+
           docker run --rm --privileged torizon/binfmt
 
           scripts/createFromTemplate.ps1 `
@@ -45,6 +49,11 @@ jobs:
             false
 
           cd "${env:GITHUB_WORKSPACE}/${env:PROJECT_FOLDER}CITest"
+
+          $_settingsJson = Get-Content -Path ".vscode/settings.json" | ConvertFrom-Json
+          $_settingsJson.torizon_arch = $env:TORIZON_ARCH
+          Set-Content -Path ".vscode/settings.json" -Value ($_settingsJson | ConvertTo-Json) -Encoding UTF8
+
           # TODO: this is bad, but it's the only way to make it work for now
           chmod 777 . -R
 

--- a/.github/workflows/build-debug-python.yaml
+++ b/.github/workflows/build-debug-python.yaml
@@ -15,20 +15,24 @@ jobs:
         project:
           - folder: python3Console
             container: python3-console
-            arch: arm64
-
+            vendor: "{ arch: 'arm64', torizon_arch: 'aarch64' }"
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build ${{ matrix.project.folder }} Dockerfile.debug
+      - name: Build ${{ matrix.project.folder }} Dockerfile
         shell: pwsh
         env:
           PROJECT_FOLDER: ${{ matrix.project.folder }}
           PROJECT_CONTAINER: ${{ matrix.project.container }}
-          PROJECT_ARCH: ${{ matrix.project.arch }}
+          VENDOR: ${{ matrix.project.vendor }}
+          DOCKER_LOGIN: localhost:5002
 
         run: |
+          $_vendor = ($env:VENDOR | ConvertFrom-Json)
+          $env:TORIZON_ARCH = $_vendor.torizon_arch
+          $env:PROJECT_ARCH = $_vendor.arch
+
           docker run --rm --privileged torizon/binfmt
 
           scripts/createFromTemplate.ps1 `
@@ -41,4 +45,9 @@ jobs:
             false
 
           cd "${env:GITHUB_WORKSPACE}/${env:PROJECT_FOLDER}CITest"
+
+          $_settingsJson = Get-Content -Path ".vscode/settings.json" | ConvertFrom-Json
+          $_settingsJson.torizon_arch = $env:TORIZON_ARCH
+          Set-Content -Path ".vscode/settings.json" -Value ($_settingsJson | ConvertTo-Json) -Encoding UTF8
+
           ./.vscode/tasks.ps1 run build-container-torizon-debug-${env:PROJECT_ARCH}

--- a/.github/workflows/build-debug-rust.yaml
+++ b/.github/workflows/build-debug-rust.yaml
@@ -15,20 +15,24 @@ jobs:
         project:
           - folder: rustSlint
             container: rust-slint
-            arch: arm64
-
+            vendor: "{ arch: 'arm64', torizon_arch: 'aarch64' }"
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build ${{ matrix.project.folder }} Dockerfile.debug
+      - name: Build ${{ matrix.project.folder }} Dockerfile
         shell: pwsh
         env:
           PROJECT_FOLDER: ${{ matrix.project.folder }}
           PROJECT_CONTAINER: ${{ matrix.project.container }}
-          PROJECT_ARCH: ${{ matrix.project.arch }}
+          VENDOR: ${{ matrix.project.vendor }}
+          DOCKER_LOGIN: localhost:5002
 
         run: |
+          $_vendor = ($env:VENDOR | ConvertFrom-Json)
+          $env:TORIZON_ARCH = $_vendor.torizon_arch
+          $env:PROJECT_ARCH = $_vendor.arch
+
           docker run --rm --privileged torizon/binfmt
 
           scripts/createFromTemplate.ps1 `
@@ -41,6 +45,11 @@ jobs:
             false
 
           cd "${env:GITHUB_WORKSPACE}/${env:PROJECT_FOLDER}CITest"
+
+          $_settingsJson = Get-Content -Path ".vscode/settings.json" | ConvertFrom-Json
+          $_settingsJson.torizon_arch = $env:TORIZON_ARCH
+          Set-Content -Path ".vscode/settings.json" -Value ($_settingsJson | ConvertTo-Json) -Encoding UTF8
+
           # TODO: this is bad, but it's the only way to make it work for now
           chmod 777 . -R
 

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -15,8 +15,7 @@ jobs:
         project:
           - folder: python3Console
             container: python3-console
-            arch: arm64
-
+            vendor: "{ arch: 'arm64', torizon_arch: 'aarch64' }"
 
     steps:
       - uses: actions/checkout@v3
@@ -26,10 +25,14 @@ jobs:
         env:
           PROJECT_FOLDER: ${{ matrix.project.folder }}
           PROJECT_CONTAINER: ${{ matrix.project.container }}
-          PROJECT_ARCH: ${{ matrix.project.arch }}
+          VENDOR: ${{ matrix.project.vendor }}
           DOCKER_LOGIN: localhost:5002
 
         run: |
+          $_vendor = ($env:VENDOR | ConvertFrom-Json)
+          $env:TORIZON_ARCH = $_vendor.torizon_arch
+          $env:PROJECT_ARCH = $_vendor.arch
+
           docker run --rm --privileged torizon/binfmt
 
           scripts/createFromTemplate.ps1 `
@@ -42,4 +45,9 @@ jobs:
             false
 
           cd "${env:GITHUB_WORKSPACE}/${env:PROJECT_FOLDER}CITest"
+
+          $_settingsJson = Get-Content -Path ".vscode/settings.json" | ConvertFrom-Json
+          $_settingsJson.torizon_arch = $env:TORIZON_ARCH
+          Set-Content -Path ".vscode/settings.json" -Value ($_settingsJson | ConvertTo-Json) -Encoding UTF8
+
           ./.vscode/tasks.ps1 run build-container-torizon-release-${env:PROJECT_ARCH}

--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -15,8 +15,7 @@ jobs:
         project:
           - folder: rustSlint
             container: rust-slint
-            arch: arm64
-
+            vendor: "{ arch: 'arm64', torizon_arch: 'aarch64' }"
 
     steps:
       - uses: actions/checkout@v3
@@ -26,10 +25,14 @@ jobs:
         env:
           PROJECT_FOLDER: ${{ matrix.project.folder }}
           PROJECT_CONTAINER: ${{ matrix.project.container }}
-          PROJECT_ARCH: ${{ matrix.project.arch }}
+          VENDOR: ${{ matrix.project.vendor }}
           DOCKER_LOGIN: localhost:5002
 
         run: |
+          $_vendor = ($env:VENDOR | ConvertFrom-Json)
+          $env:TORIZON_ARCH = $_vendor.torizon_arch
+          $env:PROJECT_ARCH = $_vendor.arch
+
           docker run --rm --privileged torizon/binfmt
 
           scripts/createFromTemplate.ps1 `
@@ -42,4 +45,9 @@ jobs:
             false
 
           cd "${env:GITHUB_WORKSPACE}/${env:PROJECT_FOLDER}CITest"
+
+          $_settingsJson = Get-Content -Path ".vscode/settings.json" | ConvertFrom-Json
+          $_settingsJson.torizon_arch = $env:TORIZON_ARCH
+          Set-Content -Path ".vscode/settings.json" -Value ($_settingsJson | ConvertTo-Json) -Encoding UTF8
+
           ./.vscode/tasks.ps1 run build-container-torizon-release-${env:PROJECT_ARCH}

--- a/assets/json/torizonPackages.json
+++ b/assets/json/torizonPackages.json
@@ -1,6 +1,6 @@
 {
-    "deps": [
+    "prodRuntimeDeps": [
     ],
-    "devDeps": [
+    "devRuntimeDeps": [
     ]
 }

--- a/cConsole/Dockerfile
+++ b/cConsole/Dockerfile
@@ -22,8 +22,8 @@ ARG IMAGE_ARCH
 RUN apt-get -q -y update && \
     apt-get -q -y install \
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/cConsole/Dockerfile.sdk
+++ b/cConsole/Dockerfile.sdk
@@ -30,8 +30,8 @@ RUN apt-get -q -y update && \
 RUN apt-get -q -y update && \
     apt-get -q -y install \
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/cmakeConsole/Dockerfile
+++ b/cmakeConsole/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get -q -y update && \
     apt-get -q -y install \
     cmake \
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/cmakeConsole/Dockerfile.sdk
+++ b/cmakeConsole/Dockerfile.sdk
@@ -32,8 +32,8 @@ RUN apt-get -q -y update && \
 RUN apt-get -q -y update && \
     apt-get -q -y install \
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/cppConsole/Dockerfile
+++ b/cppConsole/Dockerfile
@@ -22,8 +22,8 @@ ARG IMAGE_ARCH
 RUN apt-get -q -y update && \
     apt-get -q -y install \
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/cppConsole/Dockerfile.sdk
+++ b/cppConsole/Dockerfile.sdk
@@ -31,8 +31,8 @@ RUN apt-get -q -y update && \
 RUN apt-get -q -y update && \
     apt-get -q -y install \
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/cppQML/Dockerfile
+++ b/cppQML/Dockerfile
@@ -72,8 +72,8 @@ RUN apt-get -q -y update && \
     libqt6opengl6-dev \
     # ADD YOUR PACKAGES HERE
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/cppQML/Dockerfile.sdk
+++ b/cppQML/Dockerfile.sdk
@@ -78,8 +78,8 @@ RUN apt-get -q -y update && \
 RUN apt-get -q -y update && \
     apt-get -q -y install \
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/cppSlint/Dockerfile
+++ b/cppSlint/Dockerfile
@@ -38,8 +38,8 @@ ENV PATH=/cargo/bin:/rust/bin:$PATH
 RUN apt-get -q -y update && \
     apt-get -q -y install \
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/cppSlint/Dockerfile.sdk
+++ b/cppSlint/Dockerfile.sdk
@@ -30,8 +30,8 @@ ARG APP_ROOT
 RUN apt-get -q -y update && \
     apt-get -q -y install \
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/dotnetAvaloniaFrameBuffer/Dockerfile
+++ b/dotnetAvaloniaFrameBuffer/Dockerfile
@@ -73,8 +73,8 @@ RUN apt-get -q -y update && \
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
     # ADD YOUR PACKAGES HERE
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_prod_start__
+    # __torizon_packages_prod_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     libice6 \
     libsm6 \

--- a/gambasForms/Dockerfile
+++ b/gambasForms/Dockerfile
@@ -35,8 +35,8 @@ WORKDIR /build
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
     # ADD YOUR PACKAGES HERE
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
 	&& apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/*
 

--- a/javaForms/Dockerfile
+++ b/javaForms/Dockerfile
@@ -41,8 +41,8 @@ RUN apt-get -q -y update && \
     msopenjdk-21 \
     # ADD YOUR PACKAGES HERE
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/monoCsharpForms/Dockerfile
+++ b/monoCsharpForms/Dockerfile
@@ -28,8 +28,8 @@ ARG APP_ROOT
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
     # ADD YOUR PACKAGES HERE
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
 	apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/*

--- a/nodeElectron/Dockerfile
+++ b/nodeElectron/Dockerfile
@@ -68,8 +68,8 @@ RUN apt-get -q -y update && \
     libasound2 \
     curl \
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/nodeJSTypeScript/Dockerfile
+++ b/nodeJSTypeScript/Dockerfile
@@ -34,8 +34,8 @@ RUN apt-get -q -y update && \
     make \
     curl \
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && apt-get clean && apt-get autoremove && \
     rm -rf /var/lib/apt/lists/*

--- a/rustConsole/Dockerfile
+++ b/rustConsole/Dockerfile
@@ -28,8 +28,8 @@ RUN apt-get update && \
     gcc-aarch64-linux-gnu \
     # ADD YOUR PACKAGES HERE
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/rustConsole/Dockerfile.sdk
+++ b/rustConsole/Dockerfile.sdk
@@ -26,8 +26,8 @@ RUN apt-get update && \
     gcc-aarch64-linux-gnu \
     # ADD YOUR PACKAGES HERE
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/rustSlint/Dockerfile
+++ b/rustSlint/Dockerfile
@@ -48,8 +48,8 @@ RUN mkdir -p /cargo/registry && chmod 777 /cargo/registry
 RUN apt-get -q -y update && \
     apt-get -q -y install \
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/rustSlint/Dockerfile.sdk
+++ b/rustSlint/Dockerfile.sdk
@@ -54,8 +54,8 @@ RUN apt-get -q -y update && \
 RUN apt-get -q -y update && \
     apt-get -q -y install \
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/scripts/createDockerComposeProduction.ps1
+++ b/scripts/createDockerComposeProduction.ps1
@@ -119,7 +119,14 @@ if ([string]::IsNullOrEmpty($tag)) {
     }
 }
 
-$objSettings = Get-Content ("$compoFilePath/.vscode/settings.json") | `
+if ($null -eq $env:TASKS_CUSTOM_SETTINGS_JSON) {
+    $env:TASKS_CUSTOM_SETTINGS_JSON = "settings.json"
+} else {
+    Write-Host "ℹ️ :: CUSTOM SETTINGS :: ℹ️"
+    Write-Host "Using custom settings file: $env:TASKS_CUSTOM_SETTINGS_JSON"
+}
+
+$objSettings = Get-Content ("$compoFilePath/.vscode/$env:TASKS_CUSTOM_SETTINGS_JSON") | `
     Out-String | ConvertFrom-Json
 $localRegistry = $objSettings.host_ip
 

--- a/scripts/createFromTemplate.ps1
+++ b/scripts/createFromTemplate.ps1
@@ -140,11 +140,30 @@ Copy-Item "$templateFolder/../scripts/shareWSLPorts.ps1" "$location/.conf/"
 Copy-Item "$templateFolder/../scripts/createDockerComposeProduction.ps1" "$location/.conf"
 Copy-Item "$templateFolder/../scripts/torizonPackages.ps1" "$location/.conf"
 Copy-Item "$templateFolder/../scripts/tasks.ps1" "$location/.vscode"
-Copy-Item "$templateFolder/../assets/json/torizonPackages.json" "$location/"
 Copy-Item "$templateFolder/../scripts/bash/tcb-env-setup.sh" "$location/.conf"
 Copy-Item "$templateFolder/../scripts/torizonIO.ps1" "$location/.conf"
 Copy-Item "$templateFolder/../scripts/checkCIEnv.ps1" "$location/.conf"
 Copy-Item "$templateFolder/../scripts/validateDepsRunning.ps1" "$location/.conf"
+
+
+$_torPackagesJson = Get-Content -Path "$templateFolder/../assets/json/torizonPackages.json" | ConvertFrom-Json
+
+# Check also the build part of Dockerfile, for the presence of torizon_packages_build
+$dockerfileLines = Get-Content -Path "$templateFolder/Dockerfile"
+
+$buildDepDockerfile = $false
+foreach ($line in $dockerfileLines) {
+    if ($line.Contains("torizon_packages_build")) {
+        $buildDepDockerfile = $true
+        break
+    }
+}
+
+if ((Test-Path -Path "$templateFolder/Dockerfile.sdk") -Or ($buildDepDockerfile)) {
+    $_torPackagesJson | Add-Member -NotePropertyName buildDeps -NotePropertyValue @()
+}
+# Save the modified JSON object to a file
+Set-Content -Path "$location/torizonPackages.json" -Value ($_torPackagesJson | ConvertTo-Json) -Encoding UTF8
 
 # Check if there are scripts defined in the .conf/deps.json of the template and, if so,
 # copy them to the .conf of the project

--- a/scripts/tasks.ps1
+++ b/scripts/tasks.ps1
@@ -68,9 +68,16 @@ if ($env:TASKS_USE_PWSH_INSTEAD_BASH -eq $true) {
     $_usePwshInsteadBash = $false;
 }
 
+if ($null -eq $env:TASKS_CUSTOM_SETTINGS_JSON) {
+    $env:TASKS_CUSTOM_SETTINGS_JSON = "settings.json"
+} else {
+    Write-Host "ℹ️ :: CUSTOM SETTINGS :: ℹ️"
+    Write-Host "Using custom settings file: $env:TASKS_CUSTOM_SETTINGS_JSON"
+}
+
 try {
     $tasksFileContent = Get-Content $PSScriptRoot/tasks.json
-    $settingsFileContent = Get-Content $PSScriptRoot/settings.json
+    $settingsFileContent = Get-Content $PSScriptRoot/$env:TASKS_CUSTOM_SETTINGS_JSON
     $json = $tasksFileContent | ConvertFrom-Json
     $settings = $settingsFileContent | ConvertFrom-Json
     $inputs = $json.inputs
@@ -215,7 +222,7 @@ function checkTorizonInputs ([System.Collections.ArrayList] $list) {
             foreach ($matchValue in $maches) {
                 $matchValue = $matchValue.Value
                 $item = $item.Replace(
-                    "`${command:torizon_${matchValue}}", 
+                    "`${command:torizon_${matchValue}}",
                     "`${config:torizon_${matchValue}}"
                 )
             }
@@ -242,7 +249,7 @@ function checkDockerInputs ([System.Collections.ArrayList] $list) {
             foreach ($matchValue in $maches) {
                 $matchValue = $matchValue.Value
                 $item = $item.Replace(
-                    "`${command:docker_${matchValue}}", 
+                    "`${command:docker_${matchValue}}",
                     "`${config:docker_${matchValue}}"
                 )
             }
@@ -273,7 +280,7 @@ function checkTCBInputs ([System.Collections.ArrayList] $list) {
                 }
 
                 $item = $item.Replace(
-                    "`${command:tcb.getNextPackageVersion}", 
+                    "`${command:tcb.getNextPackageVersion}",
                     "$_next"
                 )
             }
@@ -287,7 +294,7 @@ function checkTCBInputs ([System.Collections.ArrayList] $list) {
             foreach ($matchValue in $maches) {
                 $matchValue = $matchValue.Value
                 $item = $item.Replace(
-                    "`${command:tcb.${matchValue}}", 
+                    "`${command:tcb.${matchValue}}",
                     "`${config:tcb.${matchValue}}"
                 )
             }
@@ -379,7 +386,7 @@ function bashVariables ([System.Collections.ArrayList] $list) {
             # then we continue because these are meant to be expanded
             if (
                 $item.Contains("`$global:") -or
-                $item.Contains("`$env:") -or 
+                $item.Contains("`$env:") -or
                 $item.Contains("`${")
             ) {
                 [void]$ret.Add($item)
@@ -544,7 +551,7 @@ function runTask () {
                         )
                     } else {
                         if (
-                            $null -eq 
+                            $null -eq
                             [System.Environment]::GetEnvironmentVariable($env)
                         ) {
                             $_env = _parseEnvs $env $task
@@ -648,7 +655,7 @@ function getCliInputs () {
 # main()
 # set the relative workspaceFolder (following the pattern that VS Code expects)
 if (
-    ($null -eq $env:APOLLOX_WORKSPACE) -and 
+    ($null -eq $env:APOLLOX_WORKSPACE) -and
     ($env:APOLLOX_CONTAINER -ne 1)
 ) {
     $Global:workspaceFolder = Join-Path $PSScriptRoot ..

--- a/scripts/torizonPackages.ps1
+++ b/scripts/torizonPackages.ps1
@@ -20,14 +20,15 @@ $TORIZON_ARCH = $args[0]
 
 if ($TORIZON_ARCH -eq "aarch64") {
     $TORIZON_ARCH = "arm64"
-}
-
-if ($TORIZON_ARCH -eq "armv7l") {
+} elseif ($TORIZON_ARCH -eq "armv7l") {
     $TORIZON_ARCH = "armhf"
-}
-
-if ($TORIZON_ARCH -eq "x86_64") {
+} elseif ($TORIZON_ARCH -eq "x86_64") {
     $TORIZON_ARCH = "amd64"
+} elseif ($TORIZON_ARCH -eq "riscv") {
+    $TORIZON_ARCH = "riscv"
+} else {
+    Write-Host -ForegroundColor DarkRed "❌ undefined target device architecture, Set Default the device before applying packages"
+    exit 69
 }
 
 # get the files content
@@ -35,6 +36,17 @@ function _getFileLines ($file) {
     [string[]] $lines = Get-Content -Path $file
 
     return $lines
+}
+
+function _addDepString ([string]$value) {
+
+    # If the arch of the package has been explicitly specified, don't add the
+    # target arch in the end
+    if ($value.Contains(":")) {
+        return "`t    ${value} \"
+    } else {
+        return "`t    ${value}:${TORIZON_ARCH} \"
+    }
 }
 
 # replace the dev and prod sections
@@ -65,16 +77,34 @@ function _ReplaceSection ([string[]]$fileLines, [string]$section) {
             $_stopAdd = $true
 
             $_json = Get-Content -Path "torizonPackages.json" | ConvertFrom-Json
-            $_devPacks = $_json.devDeps
-            $_prodPacks = $_json.deps
 
-            if ($section.Contains("dev")) {
+            $_buildPacks = $_json.buildDeps
+
+            # Adding this if to maintain backwards compatibility
+            if ( $_json.PSobject.Properties.name -match "devRuntimeDeps") {
+                $_devPacks = $_json.devRuntimeDeps
+            } else {
+                $_devPacks = $_json.devDeps
+            }
+
+            # Adding this if to maintain backwards compatibility
+            if ( $_json.PSobject.Properties.name -match "prodRuntimeDeps") {
+                $_prodPacks = $_json.prodRuntimeDeps
+            } else {
+                $_prodPacks = $_json.deps
+            }
+
+            if ($section.Contains("build")) {
+                foreach ($pack in $_buildPacks) {
+                    $_newFileContent.Add($(_addDepString $pack))
+                }
+            } elseif ($section.Contains("dev")) {
                 foreach ($pack in $_devPacks) {
-                    $_newFileContent.Add("`t${pack}:${TORIZON_ARCH} \")
+                    $_newFileContent.Add($(_addDepString $pack))
                 }
             } elseif ($section.Contains("prod")) {
                 foreach ($pack in $_prodPacks) {
-                    $_newFileContent.Add("`t${pack}:${TORIZON_ARCH} \")
+                    $_newFileContent.Add($(_addDepString $pack))
                 }
             }
         }
@@ -101,9 +131,9 @@ Write-Host "Applying torizonPackages.json ..."
 if (Test-Path -Path "Dockerfile.debug") {
     Write-Host "Applying to Dockerfile.debug ..."
     $debugDockerfile = _getFileLines "Dockerfile.debug"
-
-    _ReplaceSection $debugDockerfile "torizon_packages_dev" `
-        | Out-File -FilePath "Dockerfile.debug"
+    $debugDockerfile = `
+        _ReplaceSection $debugDockerfile "torizon_packages_dev" `
+            | Out-File -FilePath "Dockerfile.debug"
 
     Write-Host -ForegroundColor DarkGreen "✅ Dockerfile.debug"
 }
@@ -113,18 +143,19 @@ if (Test-Path -Path "Dockerfile.sdk") {
     Write-Host "Applying to Dockerfile.sdk ..."
     $debugDockerfileSDK = _getFileLines "Dockerfile.sdk"
     $debugDockerfileSDK = `
-        _ReplaceSection $debugDockerfileSDK "torizon_packages_prod"
-    _ReplaceSection $debugDockerfileSDK "torizon_packages_dev" `
-        | Out-File -FilePath "Dockerfile.sdk"
+        _ReplaceSection $debugDockerfileSDK "torizon_packages_build" `
+            | Out-File -FilePath "Dockerfile.sdk"
     Write-Host -ForegroundColor DarkGreen "✅ Dockerfile.sdk"
 }
 
 # Dockerfile
 Write-Host "Applying to Dockerfile ..."
 $Dockerfile = _getFileLines "Dockerfile"
-$Dockerfile = _ReplaceSection $Dockerfile "torizon_packages_prod"
-_ReplaceSection $Dockerfile "torizon_packages_dev" `
-    | Out-File -FilePath "Dockerfile"
+$Dockerfile = `
+    _ReplaceSection $Dockerfile "torizon_packages_prod"
+$Dockerfile = `
+    _ReplaceSection $Dockerfile "torizon_packages_build" `
+        | Out-File -FilePath "Dockerfile"
 Write-Host -ForegroundColor DarkGreen "✅ Dockerfile"
 
 Write-Host "torizonPackages.json applied"

--- a/zigConsole/Dockerfile
+++ b/zigConsole/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get -q -y update && \
     apt-get -q -y install \
     wget unzip \
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \

--- a/zigConsole/Dockerfile.sdk
+++ b/zigConsole/Dockerfile.sdk
@@ -23,8 +23,8 @@ RUN apt-get update && \
     apt-get install -y \
     # ADD YOUR PACKAGES HERE
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
-    # __torizon_packages_dev_start__
-    # __torizon_packages_dev_end__
+    # __torizon_packages_build_start__
+    # __torizon_packages_build_end__
 # DO NOT REMOVE THIS LABEL: this is used for VS Code automation
     && \
     apt-get clean && apt-get autoremove && \


### PR DESCRIPTION
…Deps)

torizonPackages.json: Separate the dependencies used to build/compile the code (the ones on Dockerfile.sdk and on the build part of the Dockerfile), which are now on buildDeps, from the runtime dependencies, which are now on devRuntimeDeps(changed from devDeps) for the Dockerfile.debug and on prodRuntimeDeps (changed from deps) for the runtime part of the Dockerfile.

Fixes: #205