### PR TITLE
Bump Slint to version 1.7.0 and switch for winit-wayland to Linuxkms …

### DIFF
--- a/cppSlint/Dockerfile
+++ b/cppSlint/Dockerfile
@@ -1,9 +1,9 @@
 # ARGUMENTS --------------------------------------------------------------------
 ##
 # Base container version
-# Using Slint v1.5.1 base images
+# Using Slint v1.7.0 base images
 ##
-ARG CROSS_SDK_BASE_TAG=3.3.0-bookworm-1.5.1
+ARG CROSS_SDK_BASE_TAG=3.3.0-bookworm-1.7.0
 ARG BASE_VERSION=3.3.0
 
 ##
@@ -101,7 +101,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
 	&& apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/*
 
 # Default to the Skia backend for best performance
-ENV SLINT_BACKEND=winit-skia
+ENV SLINT_BACKEND=linuxkms-skia
 # Default to Slint running in fullscreen
 ENV SLINT_FULLSCREEN=1
 

--- a/cppSlint/Dockerfile.debug
+++ b/cppSlint/Dockerfile.debug
@@ -6,9 +6,9 @@ ARG IMAGE_ARCH=
 
 ##
 # Base container version
-# Using the Slint v1.5.1 base images
+# Using the Slint v1.7.0 base images
 ##
-ARG BASE_VERSION=3.3.0-bookworm-1.5.1
+ARG BASE_VERSION=3.3.0-bookworm-1.7.0
 
 ##
 # Application root directory inside the container
@@ -87,7 +87,7 @@ RUN apt-get -q -y update && \
     rm -rf /var/lib/apt/lists/*
 
 # Default to the Skia backend for best performance
-ENV SLINT_BACKEND=winit-skia
+ENV SLINT_BACKEND=linuxkms-skia
 # Default to Slint running in fullscreen
 ENV SLINT_FULLSCREEN=1
 

--- a/cppSlint/Dockerfile.sdk
+++ b/cppSlint/Dockerfile.sdk
@@ -1,8 +1,8 @@
 # ARGUMENTS --------------------------------------------------------------------
 ##
-# Using the Slint v1.5.1 base images
+# Using the Slint v1.7.0 base images
 ##
-ARG CROSS_SDK_BASE_TAG=3.3.0-bookworm-1.5.1
+ARG CROSS_SDK_BASE_TAG=3.3.0-bookworm-1.7.0
 
 ##
 # Board architecture
@@ -38,7 +38,7 @@ RUN apt-get -q -y update && \
     rm -rf /var/lib/apt/lists/*
 
 # Default to the Skia backend for best performance
-ENV SLINT_BACKEND=winit-skia
+ENV SLINT_BACKEND=linuxkms-skia
 # Default to Slint running in fullscreen
 ENV SLINT_FULLSCREEN=1
 

--- a/cppSlint/docker-compose.yml
+++ b/cppSlint/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       context: .
       dockerfile: Dockerfile.debug
     image: ${LOCAL_REGISTRY}:5002/__container__-debug:${TAG}
+    environment:
+      - ACCEPT_FSL_EULA=1
     ports:
       # SSH debug
       - 2231:2231
@@ -17,6 +19,9 @@ services:
       - type: bind
         source: /dev
         target: /dev
+      - type: bind
+        source: /run/udev
+        target: /run/udev
     device_cgroup_rules:
       # ... for tty0
       - "c 4:0 rmw"
@@ -27,42 +32,14 @@ services:
       - "c 199:* rmw"
       # ... for /dev/dri devices
       - "c 226:* rmw"
-    depends_on: [
-      weston
-    ]
 
   __container__:
     build:
       context: .
       dockerfile: Dockerfile
     image: ${DOCKER_LOGIN}/__container__:${TAG}
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-    device_cgroup_rules:
-      # ... for tty0
-      - "c 4:0 rmw"
-      # ... for tty7
-      - "c 4:7 rmw"
-      # ... for /dev/input devices
-      - "c 13:* rmw"
-      - "c 199:* rmw"
-      # ... for /dev/dri devices
-      - "c 226:* rmw"
-    depends_on: [
-      weston
-    ]
-
-  weston:
-    image: torizon/weston${GPU}:3
     environment:
       - ACCEPT_FSL_EULA=1
-    # Required to get udev events from host udevd via netlink
-    network_mode: host
     volumes:
       - type: bind
         source: /tmp
@@ -73,14 +50,9 @@ services:
       - type: bind
         source: /run/udev
         target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
     device_cgroup_rules:
       # ... for tty0
       - "c 4:0 rmw"
-      # ... for tty1
-      - "c 4:1 rmw"
       # ... for tty7
       - "c 4:7 rmw"
       # ... for /dev/input devices

--- a/rustSlint/Dockerfile
+++ b/rustSlint/Dockerfile
@@ -1,9 +1,9 @@
 # ARGUMENTS --------------------------------------------------------------------
 ##
 # Base container version
-# Using Slint v1.5.1 base images
+# Using Slint v1.7.0 base images
 ##
-ARG CROSS_SDK_BASE_TAG=3.3.0-bookworm-1.5.1
+ARG CROSS_SDK_BASE_TAG=3.3.0-bookworm-1.7.0
 ARG BASE_VERSION=3.3.0
 
 ##
@@ -108,7 +108,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
 
 
 # Default to the Skia backend for best performance
-ENV SLINT_BACKEND=winit-skia
+ENV SLINT_BACKEND=linuxkms-skia
 # Default to Slint running in fullscreen
 ENV SLINT_FULLSCREEN=1
 

--- a/rustSlint/Dockerfile.debug
+++ b/rustSlint/Dockerfile.debug
@@ -6,9 +6,9 @@ ARG IMAGE_ARCH=
 
 ##
 # Base container version
-# Using Slint v1.5.1 base images
+# Using Slint v1.7.0 base images
 ##
-ARG BASE_VERSION=3.3.0-bookworm-1.5.1
+ARG BASE_VERSION=3.3.0-bookworm-1.7.0
 
 ##
 # Directory of the application inside container
@@ -88,7 +88,7 @@ RUN apt-get -q -y update && \
     rm -rf /var/lib/apt/lists/*
 
 # Default to the Skia backend for best performance
-ENV SLINT_BACKEND=winit-skia
+ENV SLINT_BACKEND=linuxkms-skia
 # Default to Slint running in fullscreen
 ENV SLINT_FULLSCREEN=1
 

--- a/rustSlint/Dockerfile.sdk
+++ b/rustSlint/Dockerfile.sdk
@@ -6,9 +6,9 @@ ARG IMAGE_ARCH=
 
 ##
 # Base container version
-# Using Slint v1.5.1 base images
+# Using Slint v1.7.0 base images
 ##
-ARG CROSS_SDK_BASE_TAG=3.3.0-bookworm-1.5.1
+ARG CROSS_SDK_BASE_TAG=3.3.0-bookworm-1.7.0
 
 ##
 # Directory of the application inside container
@@ -65,7 +65,7 @@ RUN apt-get -q -y update && \
 ENV RUST_FONTCONFIG_DLOPEN=on
 
 # Default to the Skia backend for best performance
-ENV SLINT_BACKEND=winit-skia
+ENV SLINT_BACKEND=linuxkms-skia
 # Default to Slint running in fullscreen
 ENV SLINT_FULLSCREEN=1
 

--- a/rustSlint/docker-compose.yml
+++ b/rustSlint/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       context: .
       dockerfile: Dockerfile.debug
     image: ${LOCAL_REGISTRY}:5002/__container__-debug:${TAG}
+    environment:
+      - ACCEPT_FSL_EULA=1
     ports:
       # SSH debug
       - 2231:2231
@@ -17,6 +19,9 @@ services:
       - type: bind
         source: /dev
         target: /dev
+      - type: bind
+        source: /run/udev
+        target: /run/udev
     device_cgroup_rules:
       # ... for tty0
       - "c 4:0 rmw"
@@ -27,42 +32,14 @@ services:
       - "c 199:* rmw"
       # ... for /dev/dri devices
       - "c 226:* rmw"
-    depends_on: [
-      weston
-    ]
 
   __container__:
     build:
       context: .
       dockerfile: Dockerfile
     image: ${DOCKER_LOGIN}/__container__:${TAG}
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-    device_cgroup_rules:
-      # ... for tty0
-      - "c 4:0 rmw"
-      # ... for tty7
-      - "c 4:7 rmw"
-      # ... for /dev/input devices
-      - "c 13:* rmw"
-      - "c 199:* rmw"
-      # ... for /dev/dri devices
-      - "c 226:* rmw"
-    depends_on: [
-      weston
-    ]
-
-  weston:
-    image: torizon/weston${GPU}:3
     environment:
       - ACCEPT_FSL_EULA=1
-    # Required to get udev events from host udevd via netlink
-    network_mode: host
     volumes:
       - type: bind
         source: /tmp
@@ -73,14 +50,9 @@ services:
       - type: bind
         source: /run/udev
         target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
     device_cgroup_rules:
       # ... for tty0
       - "c 4:0 rmw"
-      # ... for tty1
-      - "c 4:1 rmw"
       # ... for tty7
       - "c 4:7 rmw"
       # ... for /dev/input devices


### PR DESCRIPTION
…backend

This removes the need to run a weston container.