### PR TITLE
Fix warning on startup about unrecognized renderer

### DIFF
--- a/rustSlint/Cargo.toml
+++ b/rustSlint/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-slint = { version = "1.7.*", features = [ "backend-linuxkms-noseat" ] }
+slint = { version = "1.7.*", features = [ "backend-linuxkms-noseat", "renderer-skia" ] }
 
 [build-dependencies]
 slint-build = { version = "1.7.*" }


### PR DESCRIPTION
> slint linuxkms backend: unrecognized renderer skia, falling back default

Enable the skia renderer to fix this.