### PR TITLE
Use quotes for the DOCKER_REGISTRY variable.

### DIFF
--- a/scripts/bash/tcb-env-setup.sh
+++ b/scripts/bash/tcb-env-setup.sh
@@ -6,7 +6,7 @@ shopt -s expand_aliases
 # For DockerHub the variable can be empty, by tcb platform push command
 # requires a value, so passing the default DockerHub registry to it if it is
 # empty
-if [ $DOCKER_REGISTRY = "" ]; then
+if [ "$DOCKER_REGISTRY" = "" ]; then
     export DOCKER_REGISTRY="registry-1.docker.io"
 fi
 


### PR DESCRIPTION
This avoids the following error in the terminal tab on initialization:

     *  Executing task: DOCKER_HOST= source ./.conf/tcb-env-setup.sh -s /work/dmoseley/scratch/hellotcb/storage -t 3.11.0

     ./.conf/tcb-env-setup.sh: line 9: [: =: unary operator expected