### PR TITLE
Add a task to run manual tcb commands

### DIFF
--- a/tcb/.conf/bashrc.tcb
+++ b/tcb/.conf/bashrc.tcb
@@ -1,0 +1,2 @@
+source .conf/tcb-env-setup.sh -s ${STORAGE_DIR} -t ${TCB_VERSION}
+source ~/.bashrc

--- a/tcb/.conf/update.json
+++ b/tcb/.conf/update.json
@@ -10,5 +10,9 @@
     {
         "source": "tcbuild.yaml",
         "target": "tcbuild.yaml"
+    },
+    {
+        "source": ".conf/bashrc.tcb",
+        "target": ".conf/bashrc.tcb"
     }
 ]

--- a/tcb/.vscode/tasks.json
+++ b/tcb/.vscode/tasks.json
@@ -668,6 +668,40 @@
                 "panel": "dedicated"
             }
         },
+        {
+            "label": "run-tcb-in-terminal",
+            "detail": "",
+            "hide": false,
+            "command": "DOCKER_HOST=",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}",
+                "env": {
+                    "TCB_VERSION": "${config:tcb.version}",
+                    "STORAGE_DIR": "${workspaceFolder}/storage",
+                }
+            },
+            "args": [
+                "bash",
+                "--init-file",
+                ".conf/bashrc.tcb",
+            ],
+            "problemMatcher": [
+                "$tsc"
+            ],
+            "dependsOrder": "sequence",
+            "icon": {
+                "id": "note",
+                "color": "terminal.ansiYellow"
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared",
+                "group": "tcb-setup",
+            }
+        },
     ],
     "inputs": [
         {


### PR DESCRIPTION
This adds a task to launch a terminal with tcb-env-setup.sh already sourced and the DOCKER_HOST variable cleared.
