### PR TITLE
New Slint templates

### DIFF
--- a/cppSlint/Dockerfile
+++ b/cppSlint/Dockerfile
@@ -50,7 +50,7 @@ RUN if [ "$IMAGE_ARCH" = "arm64" ] ; then \
         dpkg-divert --divert /usr/bin/cmake.real --rename /usr/bin/cmake; \
         printf '#!/bin/sh\nexport CMAKE_TOOLCHAIN_FILE=/arm64-toolchain.cmake\nexec /usr/bin/cmake.real $*\n' > /usr/bin/cmake; \
         chmod 755 /usr/bin/cmake ;\
-    elif [ "$IMAGE_ARCH" = "arm" ] ; then \
+    elif [ "$IMAGE_ARCH" = "armhf" ] ; then \
         echo armhf > /cross-toolchain-arch.txt; \
         dpkg-divert --divert /usr/bin/cmake.real --rename /usr/bin/cmake; \
         printf '#!/bin/sh\nexport CMAKE_TOOLCHAIN_FILE=/armhf-toolchain.cmake\nexec /usr/bin/cmake.real $*\n' > /usr/bin/cmake; \

--- a/cppSlint/Dockerfile
+++ b/cppSlint/Dockerfile
@@ -23,7 +23,7 @@ ARG GPU=
 ##
 # Slint Version
 ##
-ARG SLINT_VERSION=nightly
+ARG SLINT_VERSION=1.9.2
 
 # BUILD ------------------------------------------------------------------------
 FROM torizon/cross-toolchain-${IMAGE_ARCH}:${CROSS_SDK_BASE_TAG} AS build

--- a/cppSlint/Dockerfile
+++ b/cppSlint/Dockerfile
@@ -66,7 +66,7 @@ RUN \
         GITHUB_RELEASE=nightly; \
         GITHUB_FILENAME_INFIX=nightly; \
     else \
-        GITHUB_RELEASE=$SLINT_VERSION; \
+        GITHUB_RELEASE=v$SLINT_VERSION; \
         GITHUB_FILENAME_INFIX=$SLINT_VERSION; \
     fi && \
     wget -O - https://github.com/slint-ui/slint/releases/download/$GITHUB_RELEASE/Slint-cpp-$GITHUB_FILENAME_INFIX-Linux-$CROSS_TOOLCHAIN_ARCH.tar.gz \

--- a/cppSlint/Dockerfile
+++ b/cppSlint/Dockerfile
@@ -1,9 +1,8 @@
 # ARGUMENTS --------------------------------------------------------------------
 ##
 # Base container version
-# Using Slint v1.8.0 base images
 ##
-ARG CROSS_SDK_BASE_TAG=4.0.0-1.8.0
+ARG CROSS_SDK_BASE_TAG=4.0.0
 ARG BASE_VERSION=4
 
 ##
@@ -21,18 +20,86 @@ ARG APP_ROOT=
 ##
 ARG GPU=
 
+##
+# Slint Version
+##
+ARG SLINT_VERSION=nightly
 
 # BUILD ------------------------------------------------------------------------
-FROM commontorizon/slint-sdk-${IMAGE_ARCH}:${CROSS_SDK_BASE_TAG} AS build
+FROM torizon/cross-toolchain-${IMAGE_ARCH}:${CROSS_SDK_BASE_TAG} AS build
 
 ARG IMAGE_ARCH
 ARG GPU
 ARG APP_ROOT
+ARG SLINT_VERSION
 
-# Rust
-ENV RUSTUP_HOME=/rust
-ENV CARGO_HOME=/cargo
-ENV PATH=/cargo/bin:/rust/bin:$PATH
+# Install an up-to-date cmake as well as ninja and make
+RUN apt-get update && \
+    apt-get install --assume-yes gpg wget && \
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
+    apt-get update && \
+    apt-get install --assume-yes cmake ninja-build make && \
+    rm -f /etc/apt/sources.list.d/kitware.list /usr/share/keyrings/kitware-archive-keyring.gpg && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --chmod=755 armhf-toolchain.cmake arm64-toolchain.cmake /
+
+RUN if [ "$IMAGE_ARCH" = "arm64" ] ; then \
+        echo arm64 > /cross-toolchain-arch.txt; \
+        dpkg-divert --divert /usr/bin/cmake.real --rename /usr/bin/cmake; \
+        printf '#!/bin/sh\nexport CMAKE_TOOLCHAIN_FILE=/arm64-toolchain.cmake\nexec /usr/bin/cmake.real $*\n' > /usr/bin/cmake; \
+        chmod 755 /usr/bin/cmake ;\
+    elif [ "$IMAGE_ARCH" = "arm" ] ; then \
+        echo armhf > /cross-toolchain-arch.txt; \
+        dpkg-divert --divert /usr/bin/cmake.real --rename /usr/bin/cmake; \
+        printf '#!/bin/sh\nexport CMAKE_TOOLCHAIN_FILE=/armhf-toolchain.cmake\nexec /usr/bin/cmake.real $*\n' > /usr/bin/cmake; \
+        chmod 755 /usr/bin/cmake ;\
+    elif [ "$IMAGE_ARCH" = "amd64" ] ; then \
+        echo amd64 > /cross-toolchain-arch.txt; \
+    fi
+
+# Download Slint binary packages
+RUN \
+    CROSS_TOOLCHAIN_ARCH=$(cat /cross-toolchain-arch.txt) && \
+    if [ "$SLINT_VERSION" = "nightly" ]; then \
+        GITHUB_RELEASE=nightly; \
+        GITHUB_FILENAME_INFIX=nightly; \
+    else \
+        GITHUB_RELEASE=$SLINT_VERSION; \
+        GITHUB_FILENAME_INFIX=$SLINT_VERSION; \
+    fi && \
+    wget -O - https://github.com/slint-ui/slint/releases/download/$GITHUB_RELEASE/Slint-cpp-$GITHUB_FILENAME_INFIX-Linux-$CROSS_TOOLCHAIN_ARCH.tar.gz \
+    | tar xzvf - --strip-components 1 -C /usr && \
+    if [ "$SLINT_VERSION" = "nightly" ]; then \
+        echo 'set(SLINT_GITHUB_RELEASE "nightly" CACHE STRING "")' >>  armhf-toolchain.cmake ;\
+        echo 'set(SLINT_GITHUB_RELEASE "nightly" CACHE STRING "")' >>  arm64-toolchain.cmake ;\
+    fi
+
+# Install Slint build dependencies (libxcb, etc.)
+RUN \
+    --mount=type=cache,target=/var/cache/apt \
+    CROSS_TOOLCHAIN_ARCH=$(cat /cross-toolchain-arch.txt) && \
+    rm /etc/apt/sources.list.d/toradex.sources && \
+    apt-get update && \
+    apt-get install --assume-yes \
+    pkg-config \
+    libfontconfig1-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb1-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb-render0-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb-shape0-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb-xfixes0-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxkbcommon-dev:$CROSS_TOOLCHAIN_ARCH \
+    libinput-dev:$CROSS_TOOLCHAIN_ARCH \
+    libudev-dev:$CROSS_TOOLCHAIN_ARCH \
+    libdrm2:$CROSS_TOOLCHAIN_ARCH \
+    libgbm-dev:$CROSS_TOOLCHAIN_ARCH \
+    python3 \
+    clang \
+    libstdc++-11-dev:$CROSS_TOOLCHAIN_ARCH && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PKG_CONFIG_ALLOW_CROSS=1
 
 # __deps__
 RUN apt-get -q -y update && \
@@ -49,9 +116,6 @@ RUN apt-get -q -y update && \
 # get the arch and copy the /usr/lib to /usr/lib/${ARCH_TRIPLET}
 RUN ARCH_TRIPLET=$(dpkg-architecture -qDEB_HOST_MULTIARCH) && \
     cp -r /usr/lib/libslint_cpp.so /usr/lib/${ARCH_TRIPLET}/libslint_cpp.so
-
-# Don't require font-config when the compiler runs
-ENV RUST_FONTCONFIG_DLOPEN=on
 
 # Default to Ninja
 ENV CMAKE_GENERATOR=Ninja

--- a/cppSlint/Dockerfile.debug
+++ b/cppSlint/Dockerfile.debug
@@ -30,6 +30,11 @@ ARG SSHUSERNAME=
 ARG GPU=
 
 ##
+# Slint Version
+##
+ARG SLINT_VERSION=nightly
+
+##
 # Deploy Step
 ##
 FROM --platform=linux/${IMAGE_ARCH} \
@@ -40,6 +45,7 @@ ARG GPU
 ARG DEBUG_SSH_PORT
 ARG APP_ROOT
 ARG SSHUSERNAME
+ARG SLINT_VERSION
 
 # SSH for remote debug
 EXPOSE ${DEBUG_SSH_PORT}
@@ -74,6 +80,23 @@ RUN apt-get -q -y update && \
     && \
     apt-get clean && apt-get autoremove && \
     rm -rf /var/lib/apt/lists/*
+
+# Download Slint binary packages
+RUN if [ "$IMAGE_ARCH" = "arm64" ] ; then \
+        CROSS_TOOLCHAIN_ARCH=arm64 ; \
+    elif [ "$IMAGE_ARCH" = "armhf" ] ; then \
+        CROSS_TOOLCHAIN_ARCH=armhf ; \
+    fi && \
+    if [ "$SLINT_VERSION" = "nightly" ]; then \
+        GITHUB_RELEASE=nightly; \
+        GITHUB_FILENAME_INFIX=nightly; \
+    else \
+        GITHUB_RELEASE=$SLINT_VERSION; \
+        GITHUB_FILENAME_INFIX=$SLINT_VERSION; \
+    fi && \
+    wget -O - https://github.com/slint-ui/slint/releases/download/$GITHUB_RELEASE/Slint-cpp-$GITHUB_FILENAME_INFIX-Linux-$CROSS_TOOLCHAIN_ARCH.tar.gz \
+    | tar xzvf - --strip-components 1 -C /usr --wildcards --no-wildcards-match-slash "*/lib/*" && \
+    rm -rf /usr/lib/cmake/Slint
 
 # Install Slint dependencies
 RUN apt-get update \

--- a/cppSlint/Dockerfile.debug
+++ b/cppSlint/Dockerfile.debug
@@ -6,9 +6,8 @@ ARG IMAGE_ARCH=
 
 ##
 # Base container version
-# Using the Slint v1.8.0 base images
 ##
-ARG BASE_VERSION=4.0.0-1.8.0
+ARG BASE_VERSION=4.0.0
 
 ##
 # Application root directory inside the container
@@ -33,7 +32,8 @@ ARG GPU=
 ##
 # Deploy Step
 ##
-FROM commontorizon/slint-base-${IMAGE_ARCH}${GPU}:${BASE_VERSION} AS debug
+FROM --platform=linux/${IMAGE_ARCH} \
+    torizon/wayland-base${GPU}:${BASE_VERSION} AS debug
 
 ARG IMAGE_ARCH
 ARG GPU
@@ -74,6 +74,20 @@ RUN apt-get -q -y update && \
     && \
     apt-get clean && apt-get autoremove && \
     rm -rf /var/lib/apt/lists/*
+
+# Install Slint dependencies
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+    libfontconfig1 \
+    libxkbcommon0 \
+    libinput10 \
+    fonts-noto-core \
+    fonts-noto-cjk \
+    fonts-noto-cjk-extra \
+    fonts-noto-color-emoji \
+    fonts-noto-ui-core \
+    fonts-noto-ui-extra \
+    && rm -rf /var/lib/apt/lists/*
 
 # automate for torizonPackages.json
 RUN apt-get -q -y update && \

--- a/cppSlint/Dockerfile.debug
+++ b/cppSlint/Dockerfile.debug
@@ -32,7 +32,7 @@ ARG GPU=
 ##
 # Slint Version
 ##
-ARG SLINT_VERSION=nightly
+ARG SLINT_VERSION=1.9.2
 
 ##
 # Deploy Step

--- a/cppSlint/Dockerfile.debug
+++ b/cppSlint/Dockerfile.debug
@@ -91,7 +91,7 @@ RUN if [ "$IMAGE_ARCH" = "arm64" ] ; then \
         GITHUB_RELEASE=nightly; \
         GITHUB_FILENAME_INFIX=nightly; \
     else \
-        GITHUB_RELEASE=$SLINT_VERSION; \
+        GITHUB_RELEASE=v$SLINT_VERSION; \
         GITHUB_FILENAME_INFIX=$SLINT_VERSION; \
     fi && \
     wget -O - https://github.com/slint-ui/slint/releases/download/$GITHUB_RELEASE/Slint-cpp-$GITHUB_FILENAME_INFIX-Linux-$CROSS_TOOLCHAIN_ARCH.tar.gz \

--- a/cppSlint/Dockerfile.sdk
+++ b/cppSlint/Dockerfile.sdk
@@ -1,8 +1,8 @@
 # ARGUMENTS --------------------------------------------------------------------
 ##
-# Using the Slint v1.8.0 base images
+# Base container version
 ##
-ARG CROSS_SDK_BASE_TAG=4.0.0-1.8.0
+ARG CROSS_SDK_BASE_TAG=4.0.0
 
 ##
 # Board architecture
@@ -19,12 +19,89 @@ ARG GPU=
 ##
 ARG APP_ROOT=
 
+##
+# Slint Version
+##
+ARG SLINT_VERSION=nightly
+
 # BUILD ------------------------------------------------------------------------
-FROM commontorizon/slint-sdk-${IMAGE_ARCH}:${CROSS_SDK_BASE_TAG} AS build
+FROM torizon/cross-toolchain-${IMAGE_ARCH}:${CROSS_SDK_BASE_TAG} AS build
 
 ARG IMAGE_ARCH
 ARG GPU
 ARG APP_ROOT
+ARG SLINT_VERSION
+
+# Install an up-to-date cmake as well as ninja and make
+RUN apt-get update && \
+    apt-get install --assume-yes gpg wget && \
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
+    apt-get update && \
+    apt-get install --assume-yes cmake ninja-build make && \
+    rm -f /etc/apt/sources.list.d/kitware.list /usr/share/keyrings/kitware-archive-keyring.gpg && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --chmod=755 armhf-toolchain.cmake arm64-toolchain.cmake /
+
+RUN if [ "$IMAGE_ARCH" = "arm64" ] ; then \
+        echo arm64 > /cross-toolchain-arch.txt; \
+        dpkg-divert --divert /usr/bin/cmake.real --rename /usr/bin/cmake; \
+        printf '#!/bin/sh\nexport CMAKE_TOOLCHAIN_FILE=/arm64-toolchain.cmake\nexec /usr/bin/cmake.real $*\n' > /usr/bin/cmake; \
+        chmod 755 /usr/bin/cmake ;\
+    elif [ "$IMAGE_ARCH" = "arm" ] ; then \
+        echo armhf > /cross-toolchain-arch.txt; \
+        dpkg-divert --divert /usr/bin/cmake.real --rename /usr/bin/cmake; \
+        printf '#!/bin/sh\nexport CMAKE_TOOLCHAIN_FILE=/armhf-toolchain.cmake\nexec /usr/bin/cmake.real $*\n' > /usr/bin/cmake; \
+        chmod 755 /usr/bin/cmake ;\
+    elif [ "$IMAGE_ARCH" = "amd64" ] ; then \
+        echo amd64 > /cross-toolchain-arch.txt; \
+    fi
+
+# Download Slint binary packages
+RUN \
+    CROSS_TOOLCHAIN_ARCH=$(cat /cross-toolchain-arch.txt) && \
+    if [ "$SLINT_VERSION" = "nightly" ]; then \
+        GITHUB_RELEASE=nightly; \
+        GITHUB_FILENAME_INFIX=nightly; \
+    else \
+        GITHUB_RELEASE=$SLINT_VERSION; \
+        GITHUB_FILENAME_INFIX=$SLINT_VERSION; \
+    fi && \
+    wget -O - https://github.com/slint-ui/slint/releases/download/$GITHUB_RELEASE/Slint-cpp-$GITHUB_FILENAME_INFIX-Linux-$CROSS_TOOLCHAIN_ARCH.tar.gz \
+    | tar xzvf - --strip-components 1 -C /usr && \
+    if [ "$SLINT_VERSION" = "nightly" ]; then \
+        echo 'set(SLINT_GITHUB_RELEASE "nightly" CACHE STRING "")' >>  armhf-toolchain.cmake ;\
+        echo 'set(SLINT_GITHUB_RELEASE "nightly" CACHE STRING "")' >>  arm64-toolchain.cmake ;\
+    fi
+
+# Install Slint build dependencies (libxcb, etc.)
+RUN \
+    --mount=type=cache,target=/var/cache/apt \
+    CROSS_TOOLCHAIN_ARCH=$(cat /cross-toolchain-arch.txt) && \
+    rm /etc/apt/sources.list.d/toradex.sources && \
+    apt-get update && \
+    apt-get install --assume-yes \
+    pkg-config \
+    libfontconfig1-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb1-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb-render0-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb-shape0-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb-xfixes0-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxkbcommon-dev:$CROSS_TOOLCHAIN_ARCH \
+    libinput-dev:$CROSS_TOOLCHAIN_ARCH \
+    libudev-dev:$CROSS_TOOLCHAIN_ARCH \
+    libdrm2:$CROSS_TOOLCHAIN_ARCH \
+    libgbm-dev:$CROSS_TOOLCHAIN_ARCH \
+    python3 \
+    clang \
+    libstdc++-11-dev:$CROSS_TOOLCHAIN_ARCH && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PKG_CONFIG_ALLOW_CROSS=1
+
+# Default to Ninja
+ENV CMAKE_GENERATOR=Ninja
 
 # automate for torizonPackages.json
 RUN apt-get -q -y update && \

--- a/cppSlint/Dockerfile.sdk
+++ b/cppSlint/Dockerfile.sdk
@@ -65,7 +65,7 @@ RUN \
         GITHUB_RELEASE=nightly; \
         GITHUB_FILENAME_INFIX=nightly; \
     else \
-        GITHUB_RELEASE=$SLINT_VERSION; \
+        GITHUB_RELEASE=v$SLINT_VERSION; \
         GITHUB_FILENAME_INFIX=$SLINT_VERSION; \
     fi && \
     wget -O - https://github.com/slint-ui/slint/releases/download/$GITHUB_RELEASE/Slint-cpp-$GITHUB_FILENAME_INFIX-Linux-$CROSS_TOOLCHAIN_ARCH.tar.gz \

--- a/cppSlint/Dockerfile.sdk
+++ b/cppSlint/Dockerfile.sdk
@@ -22,7 +22,7 @@ ARG APP_ROOT=
 ##
 # Slint Version
 ##
-ARG SLINT_VERSION=nightly
+ARG SLINT_VERSION=1.9.2
 
 # BUILD ------------------------------------------------------------------------
 FROM torizon/cross-toolchain-${IMAGE_ARCH}:${CROSS_SDK_BASE_TAG} AS build

--- a/cppSlint/Dockerfile.sdk
+++ b/cppSlint/Dockerfile.sdk
@@ -49,7 +49,7 @@ RUN if [ "$IMAGE_ARCH" = "arm64" ] ; then \
         dpkg-divert --divert /usr/bin/cmake.real --rename /usr/bin/cmake; \
         printf '#!/bin/sh\nexport CMAKE_TOOLCHAIN_FILE=/arm64-toolchain.cmake\nexec /usr/bin/cmake.real $*\n' > /usr/bin/cmake; \
         chmod 755 /usr/bin/cmake ;\
-    elif [ "$IMAGE_ARCH" = "arm" ] ; then \
+    elif [ "$IMAGE_ARCH" = "armhf" ] ; then \
         echo armhf > /cross-toolchain-arch.txt; \
         dpkg-divert --divert /usr/bin/cmake.real --rename /usr/bin/cmake; \
         printf '#!/bin/sh\nexport CMAKE_TOOLCHAIN_FILE=/armhf-toolchain.cmake\nexec /usr/bin/cmake.real $*\n' > /usr/bin/cmake; \

--- a/rustSlint/Dockerfile
+++ b/rustSlint/Dockerfile
@@ -1,9 +1,8 @@
 # ARGUMENTS --------------------------------------------------------------------
 ##
 # Base container version
-# Using Slint v1.8.0 base images
 ##
-ARG CROSS_SDK_BASE_TAG=4.0.0-1.8.0
+ARG CROSS_SDK_BASE_TAG=4.0.0
 ARG BASE_VERSION=4
 
 ##
@@ -23,7 +22,7 @@ ARG GPU=
 
 
 # BUILD ------------------------------------------------------------------------
-FROM commontorizon/slint-sdk-${IMAGE_ARCH}:${CROSS_SDK_BASE_TAG} AS build
+FROM torizon/cross-toolchain-${IMAGE_ARCH}:${CROSS_SDK_BASE_TAG} AS build
 
 ARG IMAGE_ARCH
 ARG GPU
@@ -41,6 +40,41 @@ RUN if [ "$IMAGE_ARCH" = "arm64" ] ; then \
         echo x86_64-unknown-linux-gnu > /rust-toolchain-arch.txt; \
         echo amd64 > /cross-toolchain-arch.txt; \
     fi
+
+# Install Rust
+ENV RUSTUP_HOME=/rust
+ENV CARGO_HOME=/cargo
+ENV PATH=/cargo/bin:/rust/bin:$PATH
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN rustup target add $(cat /rust-toolchain-arch.txt)
+
+RUN mkdir -p /cargo/registry && chmod 777 /cargo/registry
+
+# Install Slint build dependencies (libxcb, etc.)
+RUN \
+    --mount=type=cache,target=/var/cache/apt \
+    CROSS_TOOLCHAIN_ARCH=$(cat /cross-toolchain-arch.txt) && \
+    rm /etc/apt/sources.list.d/toradex.sources && \
+    apt-get update && \
+    apt-get install --assume-yes \
+    pkg-config \
+    libfontconfig1-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb1-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb-render0-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb-shape0-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb-xfixes0-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxkbcommon-dev:$CROSS_TOOLCHAIN_ARCH \
+    libinput-dev:$CROSS_TOOLCHAIN_ARCH \
+    libudev-dev:$CROSS_TOOLCHAIN_ARCH \
+    libdrm2:$CROSS_TOOLCHAIN_ARCH \
+    libgbm-dev:$CROSS_TOOLCHAIN_ARCH \
+    python3 \
+    clang \
+    libstdc++-11-dev:$CROSS_TOOLCHAIN_ARCH && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PKG_CONFIG_ALLOW_CROSS=1
 
 RUN mkdir -p /cargo/registry && chmod 777 /cargo/registry
 

--- a/rustSlint/Dockerfile.debug
+++ b/rustSlint/Dockerfile.debug
@@ -6,9 +6,8 @@ ARG IMAGE_ARCH=
 
 ##
 # Base container version
-# Using Slint v1.8.0 base images
 ##
-ARG BASE_VERSION=4.0.0-1.8.0
+ARG BASE_VERSION=4.0.0
 
 ##
 # Directory of the application inside container
@@ -34,7 +33,8 @@ ARG GPU=
 ##
 # Deploy Step
 ##
-FROM commontorizon/slint-base-${IMAGE_ARCH}${GPU}:${BASE_VERSION} AS debug
+FROM --platform=linux/${IMAGE_ARCH} \
+    torizon/wayland-base${GPU}:${BASE_VERSION} AS debug
 
 ARG IMAGE_ARCH
 ARG GPU
@@ -75,6 +75,20 @@ RUN apt-get -q -y update && \
     rust-gdb && \
     apt-get clean && apt-get autoremove && \
     rm -rf /var/lib/apt/lists/*
+
+# Install Slint dependencies
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+    libfontconfig1 \
+    libxkbcommon0 \
+    libinput10 \
+    fonts-noto-core \
+    fonts-noto-cjk \
+    fonts-noto-cjk-extra \
+    fonts-noto-color-emoji \
+    fonts-noto-ui-core \
+    fonts-noto-ui-extra \
+    && rm -rf /var/lib/apt/lists/*
 
 # automate for torizonPackages.json
 RUN apt-get -q -y update && \

--- a/rustSlint/Dockerfile.sdk
+++ b/rustSlint/Dockerfile.sdk
@@ -6,9 +6,8 @@ ARG IMAGE_ARCH=
 
 ##
 # Base container version
-# Using Slint v1.8.0 base images
 ##
-ARG CROSS_SDK_BASE_TAG=4.0.0-1.8.0
+ARG CROSS_SDK_BASE_TAG=4.0.0
 
 ##
 # Directory of the application inside container
@@ -21,7 +20,7 @@ ARG APP_ROOT=
 ARG GPU=
 
 # BUILD ------------------------------------------------------------------------
-FROM commontorizon/slint-sdk-${IMAGE_ARCH}:${CROSS_SDK_BASE_TAG} AS build
+FROM torizon/cross-toolchain-${IMAGE_ARCH}:${CROSS_SDK_BASE_TAG} AS build
 
 ARG IMAGE_ARCH
 ARG GPU
@@ -38,7 +37,40 @@ RUN if [ "$IMAGE_ARCH" = "arm64" ] ; then \
         echo amd64 > /cross-toolchain-arch.txt; \
     fi
 
+# Install Rust
+ENV RUSTUP_HOME=/rust
+ENV CARGO_HOME=/cargo
+ENV PATH=/cargo/bin:/rust/bin:$PATH
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN rustup target add $(cat /rust-toolchain-arch.txt)
+
 RUN mkdir -p /cargo/registry && chmod 777 /cargo/registry
+
+# Install Slint build dependencies (libxcb, etc.)
+RUN \
+    --mount=type=cache,target=/var/cache/apt \
+    CROSS_TOOLCHAIN_ARCH=$(cat /cross-toolchain-arch.txt) && \
+    rm /etc/apt/sources.list.d/toradex.sources && \
+    apt-get update && \
+    apt-get install --assume-yes \
+    pkg-config \
+    libfontconfig1-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb1-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb-render0-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb-shape0-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxcb-xfixes0-dev:$CROSS_TOOLCHAIN_ARCH \
+    libxkbcommon-dev:$CROSS_TOOLCHAIN_ARCH \
+    libinput-dev:$CROSS_TOOLCHAIN_ARCH \
+    libudev-dev:$CROSS_TOOLCHAIN_ARCH \
+    libdrm2:$CROSS_TOOLCHAIN_ARCH \
+    libgbm-dev:$CROSS_TOOLCHAIN_ARCH \
+    python3 \
+    clang \
+    libstdc++-11-dev:$CROSS_TOOLCHAIN_ARCH && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PKG_CONFIG_ALLOW_CROSS=1
 
 # __deps__
 RUN apt-get -q -y update && \


### PR DESCRIPTION
Merge the instructions from commontorizon/slint-{base|sdk} into the containers here and base the templates on torizon/wayland-base.

Use binary Slint packages for arm to speed up the C++ build.

cc #271