### PR TITLE
Fixes on tasks.py, project-updaters and Github actions pipelines

### DIFF
--- a/.github/workflows/build-ccpp.yaml
+++ b/.github/workflows/build-ccpp.yaml
@@ -23,7 +23,7 @@ jobs:
             vendor: '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/build-debug-ccpp.yaml
+++ b/.github/workflows/build-debug-ccpp.yaml
@@ -23,7 +23,7 @@ jobs:
             vendor: '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/build-debug-dotnet.yaml
+++ b/.github/workflows/build-debug-dotnet.yaml
@@ -24,7 +24,7 @@ jobs:
             vendor:  '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/build-debug-python.yaml
+++ b/.github/workflows/build-debug-python.yaml
@@ -15,7 +15,7 @@ jobs:
             vendor:  '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/build-debug-rust.yaml
+++ b/.github/workflows/build-debug-rust.yaml
@@ -15,7 +15,7 @@ jobs:
             vendor:  '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/build-dotnet.yaml
+++ b/.github/workflows/build-dotnet.yaml
@@ -24,7 +24,7 @@ jobs:
             vendor:  '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/build-publish-torizon-dev.yaml
+++ b/.github/workflows/build-publish-torizon-dev.yaml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Xonsh
         run: |

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -15,7 +15,7 @@ jobs:
             vendor:  '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -15,7 +15,7 @@ jobs:
             vendor:  '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -9,7 +9,7 @@ jobs:
       image: node:18
     name: Spell Check
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: cspell CLI Lint
 
@@ -27,7 +27,7 @@ jobs:
       options: --user root
     name: Check EOF New Line
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check EOF New Line
 
@@ -43,7 +43,7 @@ jobs:
       options: --user root
     name: Check JSON
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check JSON
 

--- a/.github/workflows/publish-torizon-utils.yaml
+++ b/.github/workflows/publish-torizon-utils.yaml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Sanity version
         run: |

--- a/assets/github/workflows/build-application.yaml
+++ b/assets/github/workflows/build-application.yaml
@@ -8,6 +8,7 @@ jobs:
     name: Build & Deploy
     container:
       image: torizonextras/torizon-dev:dev
+      options: --user root
     steps:
       - uses: actions/checkout@v4
 

--- a/assets/github/workflows/build-application.yaml
+++ b/assets/github/workflows/build-application.yaml
@@ -9,7 +9,7 @@ jobs:
     container:
       image: torizonextras/torizon-dev:dev
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Host Absolute Workspace Path
         run: |
@@ -72,7 +72,7 @@ jobs:
           xonsh ./.vscode/tasks.xsh run platform-update-fleet
 
       - name: Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker-compose-prod
           path: |

--- a/cLvgl/.gitignore
+++ b/cLvgl/.gitignore
@@ -79,6 +79,8 @@ credentials.zip
 
 #Build directories
 build-*
+#But the build yaml file from ci/cd need to be included
+!.github/workflows/build-*
 
 .conf/.depok
 .conf/.docok

--- a/cmakeConsole/.gitignore
+++ b/cmakeConsole/.gitignore
@@ -79,6 +79,8 @@ credentials.zip
 
 #Build directories
 build-*
+#But the build yaml file from ci/cd need to be included
+!.github/workflows/build-*
 
 .conf/.depok
 .conf/.docok

--- a/cmakeGTK3/.gitignore
+++ b/cmakeGTK3/.gitignore
@@ -79,6 +79,8 @@ credentials.zip
 
 #Build directories
 build-*
+#But the build yaml file from ci/cd need to be included
+!.github/workflows/build-*
 
 .conf/.depok
 .conf/.docok

--- a/cmakeGTK4/.gitignore
+++ b/cmakeGTK4/.gitignore
@@ -79,6 +79,8 @@ credentials.zip
 
 #Build directories
 build-*
+#But the build yaml file from ci/cd need to be included
+!.github/workflows/build-*
 
 .conf/.depok
 .conf/.docok

--- a/cppConsole/.gitignore
+++ b/cppConsole/.gitignore
@@ -74,6 +74,8 @@ dkms.conf
 
 #Build directories
 build-*
+#But the build yaml file from ci/cd need to be included
+!.github/workflows/build-*
 
 # End of https://www.gitignore.io/api/c,c++,cmake
 

--- a/scripts/bash/setup-xonsh.sh
+++ b/scripts/bash/setup-xonsh.sh
@@ -13,6 +13,7 @@ fi
 set -e
 
 pipx install xonsh
+pipx ensurepath
 pipx inject xonsh distro
 pipx inject xonsh shtab
 pipx inject xonsh pyyaml
@@ -29,6 +30,9 @@ if ! grep -q "export PATH=\$PATH:\$HOME/.local/bin" ~/.bashrc; then
 fi
 
 # also for .xonshrc itself
+if [ ! -f ~/.xonshrc ]; then
+    touch ~/.xonshrc
+fi
 if ! grep -q "\$HOME/.local/bin" ~/.xonshrc; then
     echo "\$PATH.insert(0, '$HOME/.local/bin')" >> ~/.xonshrc
 fi

--- a/scripts/project-updater.xsh
+++ b/scripts/project-updater.xsh
@@ -151,7 +151,7 @@ if not second_run:
     _git_status: CommandPipeline = {}
     _git_status = !(git -C @(project_folder) status)
 
-    if "fatal: not a git repository" in _git_status.err:
+    if _git_status.err != None and "fatal: not a git repository" in _git_status.err:
         print(
             "❌ fatal: this workspace is not a git repository.",
             color=Color.RED

--- a/scripts/project-updater.xsh
+++ b/scripts/project-updater.xsh
@@ -778,4 +778,10 @@ print("✅ specific files OK", color=Color.GREEN)
 # clean up tmp
 rm -rf @(f"{project_folder}/.conf/tmp")
 
+# update metadata.json
+_project_metadata_file = open(f"{project_folder}/.conf/metadata.json", "w")
+_project_metadata["torizonOSMajor"] = _templates_metadata["TorizonOSMajor"]
+_project_metadata_file.write(json.dumps(_project_metadata, indent=4))
+_project_metadata_file.close()
+
 print("\n✅ Update done", color=Color.GREEN)

--- a/scripts/projectUpdater.ps1
+++ b/scripts/projectUpdater.ps1
@@ -2,8 +2,12 @@
 param()
 
 # include
-. "$env:HOME/.apollox/scripts/utils/formatJson.ps1"
-. "$env:HOME/.apollox/scripts/utils/replaceTasksInput.ps1"
+if ( Test-Path -Path "$env:HOME/.apollox/scripts/utils/formatJson.ps1" ) {
+    . "$env:HOME/.apollox/scripts/utils/formatJson.ps1"
+}
+if ( Test-Path -Path "$env:HOME/.apollox/scripts/utils/replaceTasksInput.ps1" ) {
+    . "$env:HOME/.apollox/scripts/utils/replaceTasksInput.ps1"
+}
 
 $errorActionPreference = "Stop"
 

--- a/scripts/projectUpdater.ps1
+++ b/scripts/projectUpdater.ps1
@@ -162,15 +162,17 @@ if ((Test-Path "$projectFolder/.conf/.template") -and (Test-Path "$projectFolder
 $_metadataJson = Get-Content "$projectFolder/.conf/metadata.json" | ConvertFrom-Json
 $templateName = $_metadataJson.templateName
 $containerName = $_metadataJson.containerName
-$_torizonOSMajor = $_metadataJson.TorizonOSMajor
 
 ##
-# FIXUP FOR THE ISSUE WITH BOOKWORM SET AS TorizonOSMajor=7
+# FIXUP FOR THE ISSUE WITH BOOKWORM SET AS TorizonOSMajor=7 on v2.8.0
 # !!!IF WE ARE USING PWSH MEANS THAT IS NOT 7 IS 6!!!
 ##
-if ($_torizonOSMajor -eq "7") {
-    $_torizonOSMajor = "6"
+if ($_metadataJson.torizonOSMajor -eq "7") {
+    $_metadataJson.torizonOSMajor = "6"
+    # Save the modified JSON object to a file
+    Set-Content -Path "$projectFolder/.conf/metadata.json" -Value ($_metadataJson | ConvertTo-Json) -Encoding UTF8
 }
+$_torizonOSMajor = $_metadataJson.torizonOSMajor
 
 $_templatesJsonTorizonMajor = $_templatesJson.TorizonOSMajor
 

--- a/scripts/utils/pip/torizon_templates_utils/tasks.py
+++ b/scripts/utils/pip/torizon_templates_utils/tasks.py
@@ -913,12 +913,16 @@ class TaskRunner:
             print(f"Parsed Args: {_args}", color=Color.YELLOW)
             print(f"Parsed Command: {_cmd_join}", color=Color.YELLOW)
 
+        # use bash to execute the VSCode tasks commands and scripts, as they
+        # are written and tested in bash. Valid just for commands of shell
+        # type, not process type ones
         _ret = subprocess.run(
             [_cmd, *_args] if not _shell else _cmd_join,
             stdout=None,
             stderr=None,
             env=os.environ,
-            shell=_shell
+            shell=_shell,
+            executable="/bin/bash" if _shell else None
         )
 
         # go back to the last cwd
@@ -927,4 +931,3 @@ class TaskRunner:
         if _ret.returncode != 0:
             print(f"> TASK [{label}] exited with error code [{_ret.returncode}] <", color=Color.RED)
             raise RuntimeError(f"Error running task: {label}")
-

--- a/tcb/.github/workflows/build-torizoncore.yaml
+++ b/tcb/.github/workflows/build-torizoncore.yaml
@@ -9,8 +9,8 @@ jobs:
     container:
       image: torizonextras/torizon-dev:dev
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         id: cache
         with:
           path: storage/


### PR DESCRIPTION
If the same env var appeared in a task and in a dependsOn task of this task, like the VSCODE_CMD on tcb-platform-push-ostree, with the tcb-unpack as dependsOn, the env var was not getting updated due to it's order on the recursive function. This commit fixes it.