### PR TITLE
Specify the docker registry as a parameter to "docker login".

### DIFF
--- a/assets/tasks/common.json
+++ b/assets/tasks/common.json
@@ -285,7 +285,8 @@
                 "login",
                 "--username",
                 "${command:docker_login}",
-                "--password-stdin"
+                "--password-stdin",
+                "${command:docker_registry}"
             ],
             "dependsOrder": "sequence",
             "icon": {


### PR DESCRIPTION
It seems that the registry needs to be on the command-line for non-DockerHub registries.  I verified this using the python template and ghcr.io.