### PR TITLE
cppQML: Remove Qt for Python extension recommendation

### DIFF
--- a/cppQML/.vscode/extensions.json
+++ b/cppQML/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
     "recommendations": [
         "ms-vscode.cpptools",
-        "twxs.cmake",
-        "seanwu.vscode-qt-for-python"
+        "twxs.cmake"
     ]
 }


### PR DESCRIPTION
This recommendation is not needed as this is a C++ template.