### PR TITLE
python3Console: Fix Dockerfile print on output

### DIFF
--- a/python3Console/Dockerfile
+++ b/python3Console/Dockerfile
@@ -52,4 +52,4 @@ WORKDIR ${APP_ROOT}
 
 ENV APP_ROOT=${APP_ROOT}
 # Activate and run the code
-CMD . ${APP_ROOT}/.venv/bin/activate && python3 src/main.py --no-sandbox
+CMD . ${APP_ROOT}/.venv/bin/activate && python3 -u src/main.py --no-sandbox


### PR DESCRIPTION
On python the output is not printed on the Docker output while the code is being executed if the unbuffered option is not added when executing the file:
https://github.com/moby/moby/issues/12447#issuecomment-93932924