### PR TITLE
Updates the docker container to enable support for am62 boards.

### DIFF
--- a/dartFlutter/Dockerfile
+++ b/dartFlutter/Dockerfile
@@ -44,7 +44,7 @@ RUN flutter-elinux clean; flutter-elinux pub get; flutter-elinux build elinux --
 
 # DEPLOY -----------------------------------------------------------------------
 
-FROM crossware.app:5050/public-repos/flutter${GPU}:${BASE_VERSION} AS final
+FROM crossware.app:5050/public-repos/flutter:${BASE_VERSION}${GPU} AS final
 
 ARG GPU
 ARG APP_ROOT

--- a/dartFlutter/Dockerfile
+++ b/dartFlutter/Dockerfile
@@ -20,6 +20,11 @@ ARG IMAGE_ARCH=
 ARG APP_ROOT=
 
 ##
+# Board GPU vendor prefix
+##
+ARG GPU=
+
+##
 # Build/Deploy Step
 ##
 
@@ -27,7 +32,6 @@ ARG APP_ROOT=
 FROM crossware.app:5050/public-repos/flutter:${SDK_BASE_VERSION} AS build
 
 ARG IMAGE_ARCH
-ARG GPU
 ARG APP_ROOT
 
 COPY . ${APP_ROOT}
@@ -40,8 +44,9 @@ RUN flutter-elinux clean; flutter-elinux pub get; flutter-elinux build elinux --
 
 # DEPLOY -----------------------------------------------------------------------
 
-FROM crossware.app:5050/public-repos/flutter:${BASE_VERSION} AS final
+FROM crossware.app:5050/public-repos/flutter${GPU}:${BASE_VERSION} AS final
 
+ARG GPU
 ARG APP_ROOT
 ARG SSHUSERNAME
 

--- a/dartFlutter/Dockerfile.debug
+++ b/dartFlutter/Dockerfile.debug
@@ -39,7 +39,7 @@ ARG SSHUSERNAME=
 # Deploy Step
 ##
 
-FROM crossware.app:5050/public-repos/flutter${GPU}:${BASE_VERSION} AS debug
+FROM crossware.app:5050/public-repos/flutter:${BASE_VERSION}${GPU} AS debug
 
 ARG IMAGE_ARCH
 ARG SSHUSERNAME

--- a/dartFlutter/Dockerfile.debug
+++ b/dartFlutter/Dockerfile.debug
@@ -25,6 +25,11 @@ ARG APP_ROOT=
 ARG DEBUG_SSH_PORT=
 
 ##
+# Board GPU vendor prefix
+##
+ARG GPU=
+
+##
 # Run as
 ##
 ARG SSHUSERNAME=
@@ -34,7 +39,7 @@ ARG SSHUSERNAME=
 # Deploy Step
 ##
 
-FROM crossware.app:5050/public-repos/flutter:${BASE_VERSION} AS debug
+FROM crossware.app:5050/public-repos/flutter${GPU}:${BASE_VERSION} AS debug
 
 ARG IMAGE_ARCH
 ARG SSHUSERNAME


### PR DESCRIPTION
dartFlutter: Enables Support for am62 boards

This pull request updates Dockerfile.debug and Dockerfile to Enable support for am62 boards.


Signed-off-by: alber.rizwan@crossware.io