### PR TITLE
scripts: use tcp://docker:2375 only on GitLab CI with Docker executor

### DIFF
--- a/scripts/check-deps.xsh
+++ b/scripts/check-deps.xsh
@@ -27,8 +27,8 @@ from torizon_templates_utils.colors import Color,BgColor,print
 # clean the workspace set device default to use the local docker engine
 $DOCKER_HOST = ""
 
-if "GITLAB_CI" in os.environ:
-    print("ℹ️ :: GITLAB_CI :: ℹ️")
+if "GITLAB_CI" in os.environ and os.path.exists("/.dockerenv"):
+    print("ℹ️ :: GITLAB_CI using docker executor :: ℹ️")
     $DOCKER_HOST = "tcp://docker:2375"
 
 # docker and docker-compose are special cases

--- a/scripts/create-docker-compose-production.xsh
+++ b/scripts/create-docker-compose-production.xsh
@@ -31,8 +31,8 @@ from torizon_templates_utils.colors import Color,BgColor,print
 
 $DOCKER_HOST = ""
 
-if "GITLAB_CI" in os.environ:
-    print("ℹ️ :: GITLAB_CI :: ℹ️")
+if "GITLAB_CI" in os.environ and os.path.exists("/.dockerenv"):
+    print("ℹ️ :: GITLAB_CI using docker executor :: ℹ️")
     $DOCKER_HOST = "tcp://docker:2375"
 
 _iterative = False

--- a/scripts/docker-login.xsh
+++ b/scripts/docker-login.xsh
@@ -29,8 +29,8 @@ from torizon_templates_utils.colors import Color,BgColor,print
 
 $DOCKER_HOST = ""
 
-if "GITLAB_CI" in os.environ:
-    print("ℹ️ :: GITLAB_CI :: ℹ️")
+if "GITLAB_CI" in os.environ and os.path.exists("/.dockerenv"):
+    print("ℹ️ :: GITLAB_CI using docker executor :: ℹ️")
     $DOCKER_HOST = "tcp://docker:2375"
 
 _iterative = False

--- a/scripts/run-container-if-not-exists.xsh
+++ b/scripts/run-container-if-not-exists.xsh
@@ -56,8 +56,8 @@ run_arguments = args.run_arguments.replace("\"", "")
 run_arguments = run_arguments.replace("'", "")
 container_name = args.container_name.replace("\"", "")
 
-if "GITLAB_CI" in os.environ:
-    print("ℹ️ :: GITLAB_CI :: ℹ️")
+if "GITLAB_CI" in os.environ and os.path.exists("/.dockerenv"):
+    print("ℹ️ :: GITLAB_CI using docker executor :: ℹ️")
     $DOCKER_HOST = "tcp://docker:2375"
 
 # debug

--- a/scripts/validate-deps-running.xsh
+++ b/scripts/validate-deps-running.xsh
@@ -22,8 +22,8 @@ from torizon_templates_utils.colors import Color,BgColor,print
 
 $DOCKER_HOST = ""
 
-if "GITLAB_CI" in os.environ:
-    print("ℹ️ :: GITLAB_CI :: ℹ️")
+if "GITLAB_CI" in os.environ and os.path.exists("/.dockerenv"):
+    print("ℹ️ :: GITLAB_CI using docker executor :: ℹ️")
     $DOCKER_HOST = "tcp://docker:2375"
 
 


### PR DESCRIPTION
GitLab CI sets the GITLAB_CI environment variable even when using the 'shell' executor. In such cases, the tcp://docker:2375 endpoint is not available, causing the scripts to fail in apollox tests due to 'Docker is not running! Error cause: Not configured'.

Fix: In addition to checking for GITLAB_CI, script now also check for the existence of /.dockerenv, which is only present inside Docker containers. This ensures DOCKER_HOST is only set when running under the Docker executor, avoiding failures in shell-based jobs.

Related-to: TIE-527