### PR TITLE
dartFlutter: Remove unused "ssh-tunnel" task

### DIFF
--- a/dartFlutter/.vscode/tasks.json
+++ b/dartFlutter/.vscode/tasks.json
@@ -101,7 +101,7 @@
             "dependsOn": [
             ],
             "icon": {
-                "id": "tools",
+                "id": "trash",
                 "color": "terminal.ansiYellow"
             },
             "presentation": {

--- a/dartFlutter/.vscode/tasks.json
+++ b/dartFlutter/.vscode/tasks.json
@@ -2,35 +2,6 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "ssh-tunnel",
-            "type": "shell",
-            "command": "sshpass",
-            "args": [
-                "-p", "${config:torizon_psswd}",
-                "ssh",
-                "-L", "42271:127.0.0.1:42271",
-                "torizon@${config:torizon_ip}"
-            ],
-            "isBackground": true,
-            "options": {
-              "shell": {
-                "executable": "/bin/bash",
-                "args": ["-c"]
-              }
-            },
-            "icon": {
-                "id": "layers",
-                "color": "terminal.ansiYellow"
-            },
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": true,
-                "panel": "shared",
-                "group": "build-execution"
-            }
-        },
-        {
             "label": "flutter-clean-arm64",
             "detail": "Clean the build folder for arm64 using the\ncontainer SDK toolchain.",
             "command": "DOCKER_HOST=",


### PR DESCRIPTION
This task became unused when the remote debugging changed from Dart to GDB.