### PR TITLE
multiRoot.code-workspace: Fix check-deps-all not waiting for input

### DIFF
--- a/multiRoot/multiRoot.code-workspace
+++ b/multiRoot/multiRoot.code-workspace
@@ -48,7 +48,7 @@
 			},
 			{
 				"label": "check-deps-all",
-				"type": "shell",
+				"type": "process",
 				"command": "xonsh",
 				"args": [
 					"${workspaceFolder}/.conf/multi-root-tasks.xsh",


### PR DESCRIPTION
Related-to: TIE-1080