### PR TITLE
all: tasks: Turn check-tunnel to service-check

### DIFF
--- a/aspnetBlazor/.vscode/tasks.json
+++ b/aspnetBlazor/.vscode/tasks.json
@@ -180,7 +180,8 @@
                 "build-container-torizon-debug-arm",
                 "push-container-torizon-debug-arm",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",
@@ -284,7 +285,8 @@
                 "build-container-torizon-debug-arm64",
                 "push-container-torizon-debug-arm64",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",

--- a/assets/tasks/common.json
+++ b/assets/tasks/common.json
@@ -1213,17 +1213,48 @@
             }
         },
         {
+            "label": "ssh-check",
+            "detail": "",
+            "hide": true,
+            "command": "xonsh",
+            "type": "shell",
+            "args": [
+                "${workspaceFolder}/.conf/service-check.xsh",
+                "ssh",
+                "${config:torizon_psswd}",
+                "${config:torizon_debug_ssh_port}",
+                "${config:torizon_login}",
+                "${config:torizon_ip}",
+                "echo ssh-ok"
+            ],
+            "dependsOrder": "sequence",
+            "problemMatcher": "$tsc",
+            "icon": {
+                "id": "repo-pull",
+                "color": "terminal.ansiYellow"
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared",
+                "group": "build-execution"
+            }
+        },
+        {
             "label": "tunnel-check",
             "detail": "",
             "hide": true,
             "command": "xonsh",
             "type": "shell",
             "args": [
-                "${workspaceFolder}/.conf/tunnel-check.xsh",
+                "${workspaceFolder}/.conf/service-check.xsh",
+                "registry",
                 "${config:torizon_psswd}",
                 "${config:torizon_ssh_port}",
                 "${config:torizon_login}",
-                "${config:torizon_ip}"
+                "${config:torizon_ip}",
+                "curl --silent --max-time 5 http://localhost:5002/v2/_catalog"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$tsc",

--- a/cLvgl/.vscode/tasks.json
+++ b/cLvgl/.vscode/tasks.json
@@ -224,7 +224,8 @@
                 "build-container-torizon-debug-arm64",
                 "push-container-torizon-debug-arm64",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",
@@ -298,7 +299,8 @@
                 "build-container-torizon-debug-arm",
                 "push-container-torizon-debug-arm",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",

--- a/cmakeConsole/.vscode/tasks.json
+++ b/cmakeConsole/.vscode/tasks.json
@@ -185,7 +185,8 @@
                 "build-container-torizon-debug-arm64",
                 "push-container-torizon-debug-arm64",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",
@@ -259,7 +260,8 @@
                 "build-container-torizon-debug-arm",
                 "push-container-torizon-debug-arm",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",

--- a/cmakeGTK3/.vscode/tasks.json
+++ b/cmakeGTK3/.vscode/tasks.json
@@ -185,7 +185,8 @@
                 "build-container-torizon-debug-arm64",
                 "push-container-torizon-debug-arm64",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",
@@ -259,7 +260,8 @@
                 "build-container-torizon-debug-arm",
                 "push-container-torizon-debug-arm",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",

--- a/cmakeGTK4/.vscode/tasks.json
+++ b/cmakeGTK4/.vscode/tasks.json
@@ -185,7 +185,8 @@
                 "build-container-torizon-debug-arm64",
                 "push-container-torizon-debug-arm64",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",
@@ -259,7 +260,8 @@
                 "build-container-torizon-debug-arm",
                 "push-container-torizon-debug-arm",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",

--- a/cppConsole/.vscode/tasks.json
+++ b/cppConsole/.vscode/tasks.json
@@ -167,7 +167,8 @@
                 "push-container-torizon-debug-arm64",
                 "pull-container-torizon-debug",
                 "run-container-torizon-debug",
-                "pos-cleanup"
+                "pos-cleanup",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",
@@ -242,7 +243,8 @@
                 "build-container-torizon-debug-arm",
                 "push-container-torizon-debug-arm",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",

--- a/cppQML/.vscode/tasks.json
+++ b/cppQML/.vscode/tasks.json
@@ -563,7 +563,8 @@
                 "qt-enterprise-remove-auth-conf",
                 "push-container-torizon-debug-arm64",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",
@@ -713,7 +714,8 @@
                 "qt-enterprise-remove-auth-conf",
                 "push-container-torizon-debug-arm",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",

--- a/cppSlint/.vscode/tasks.json
+++ b/cppSlint/.vscode/tasks.json
@@ -341,7 +341,8 @@
                 "build-container-torizon-debug-arm64",
                 "push-container-torizon-debug-arm64",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",
@@ -490,7 +491,8 @@
                 "build-container-torizon-debug-arm",
                 "push-container-torizon-debug-arm",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",

--- a/dartFlutter/.vscode/tasks.json
+++ b/dartFlutter/.vscode/tasks.json
@@ -167,7 +167,8 @@
                 "push-container-torizon-debug-arm64",
                 "pull-container-torizon-debug",
                 "run-container-torizon-debug",
-                "pos-cleanup"
+                "pos-cleanup",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",

--- a/dotnetAvalonia/.vscode/tasks.json
+++ b/dotnetAvalonia/.vscode/tasks.json
@@ -225,7 +225,8 @@
                 "push-container-torizon-debug-arm",
                 "pull-container-torizon-debug",
                 "run-container-torizon-debug",
-                "pos-cleanup"
+                "pos-cleanup",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",
@@ -295,7 +296,8 @@
                 "push-container-torizon-debug-arm64",
                 "pull-container-torizon-debug",
                 "run-container-torizon-debug",
-                "pos-cleanup"
+                "pos-cleanup",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",

--- a/dotnetAvaloniaFrameBuffer/.vscode/tasks.json
+++ b/dotnetAvaloniaFrameBuffer/.vscode/tasks.json
@@ -192,7 +192,8 @@
                 "push-container-torizon-debug-arm",
                 "pull-container-torizon-debug",
                 "run-container-torizon-debug",
-                "pos-cleanup"
+                "pos-cleanup",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",
@@ -335,7 +336,8 @@
                 "push-container-torizon-debug-arm64",
                 "pull-container-torizon-debug",
                 "run-container-torizon-debug",
-                "pos-cleanup"
+                "pos-cleanup",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",

--- a/dotnetConsole/.vscode/tasks.json
+++ b/dotnetConsole/.vscode/tasks.json
@@ -180,7 +180,8 @@
                 "build-container-torizon-debug-arm",
                 "push-container-torizon-debug-arm",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",
@@ -249,7 +250,8 @@
                 "build-container-torizon-debug-arm64",
                 "push-container-torizon-debug-arm64",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",

--- a/python3Console/.vscode/tasks.json
+++ b/python3Console/.vscode/tasks.json
@@ -138,6 +138,7 @@
                 "pull-container-torizon-debug",
                 "run-container-torizon-debug",
                 "wait-a-bit",
+                "ssh-check",
                 "stop-torizon-debug-generic",
                 "rsync-torizon-generic",
                 "start-torizon-debug-arm"
@@ -211,6 +212,7 @@
                 "pull-container-torizon-debug",
                 "run-container-torizon-debug",
                 "wait-a-bit",
+                "ssh-check",
                 "stop-torizon-debug-generic",
                 "rsync-torizon-generic",
                 "start-torizon-debug-arm64"

--- a/rustSlint/.vscode/tasks.json
+++ b/rustSlint/.vscode/tasks.json
@@ -191,7 +191,8 @@
                 "build-container-torizon-debug-arm64",
                 "push-container-torizon-debug-arm64",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",
@@ -380,7 +381,8 @@
                 "build-container-torizon-debug-arm",
                 "push-container-torizon-debug-arm",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",

--- a/scripts/create-from-template.xsh
+++ b/scripts/create-from-template.xsh
@@ -269,7 +269,7 @@ if template_scripts is None:
     cp -r @(template_folder)/../scripts/validate-deps-running.xsh @(new_project_path)/.conf/
     cp -r @(template_folder)/../scripts/apply-ci-settings-file.xsh @(new_project_path)/.conf/
     cp -r @(template_folder)/../scripts/validate-json.xsh @(new_project_path)/.conf/
-    cp -r @(template_folder)/../scripts/tunnel-check.xsh @(new_project_path)/.conf/
+    cp -r @(template_folder)/../scripts/service-check.xsh @(new_project_path)/.conf/
 else:
     for script in template_scripts:
         cp -r @(os.path.join(template_folder, "..", "scripts", script)) @(os.path.join(new_project_path, ".conf"))

--- a/scripts/service-check.xsh
+++ b/scripts/service-check.xsh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 ##
-# This script is used to create a new project from a template.
+# This script is used to check if some service is running under ssh remote
 ##
 
 # use the xonsh environment to update the OS environment
@@ -25,18 +25,20 @@ from torizon_templates_utils.errors import Error,Error_Out
 
 
 
-if len(sys.argv) != 5:
+if len(sys.argv) != 7:
     Error_Out(
-        f"Error: Expected 5 arguments, but got {len(sys.argv) -1}.\n" +
+        f"Error: Expected 7 arguments, but got {len(sys.argv) -1}.\n" +
         "Report on https://github.com/torizon/vscode-torizon-templates/issues",
         Error.EINVAL
     )
 
 
-torizon_psswd = get_arg_not_empty(1)
-torizon_ssh_port = get_arg_not_empty(2)
-torizon_user = get_arg_not_empty(3)
-torizon_ip = get_arg_not_empty(4)
+service_name = get_arg_not_empty(1)
+torizon_psswd = get_arg_not_empty(2)
+torizon_ssh_port = get_arg_not_empty(3)
+torizon_user = get_arg_not_empty(4)
+torizon_ip = get_arg_not_empty(5)
+service_check = get_arg_not_empty(6)
 
 MAX_ATTEMPTS = 15
 TIMEOUT_SECONDS = 5
@@ -45,9 +47,6 @@ SLEEP_INTERVAL = 1
 
 for i in range(1, MAX_ATTEMPTS + 1):
     try:
-        # Use curl to check registry availability
-        # --silent: suppress progress output
-        # --max-time: maximum time allowed for transfer
         with ${...}.swap(RAISE_SUBPROC_ERROR=False):
             result = !( \
                 sshpass \
@@ -57,7 +56,7 @@ for i in range(1, MAX_ATTEMPTS + 1):
                     -o UserKnownHostsFile=/dev/null \
                     -o StrictHostKeyChecking=no \
                     -o PubkeyAuthentication=no \
-                    @(torizon_user)@@(torizon_ip) curl --silent --max-time @(TIMEOUT_SECONDS) http://localhost:5002/v2/_catalog \
+                    @(torizon_user)@@(torizon_ip) @(service_check) \
             )
 
         if result.returncode == 0:
@@ -67,12 +66,12 @@ for i in range(1, MAX_ATTEMPTS + 1):
     except Exception as e:
         print(f"Exception occurred: {e}")
 
-    print(f"Attempt {i}/{MAX_ATTEMPTS}: waiting for registry...")
+    print(f"Attempt {i}/{MAX_ATTEMPTS}: waiting for {service_name}...")
     time.sleep(SLEEP_INTERVAL)
 
 
 Error_Out(
     "Max attempts reached\n" +
-    "Was not possible to get a response from the registry",
+    f"Was not possible to get a response from the {service_name}",
     Error.EFAIL
 )

--- a/zigConsole/.vscode/tasks.json
+++ b/zigConsole/.vscode/tasks.json
@@ -136,7 +136,8 @@
                 "build-container-torizon-debug-arm64",
                 "push-container-torizon-debug-arm64",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",
@@ -250,7 +251,8 @@
                 "build-container-torizon-debug-arm",
                 "push-container-torizon-debug-arm",
                 "pull-container-torizon-debug",
-                "run-container-torizon-debug"
+                "run-container-torizon-debug",
+                "ssh-check"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$msCompile",


### PR DESCRIPTION
Now we can use the same logic from check-tunnel to check any service over ssh, like ssh itself.