### PR TITLE
fix: correctly convert ms to us before calling usleep

### DIFF
--- a/cLvgl/src/main.c
+++ b/cLvgl/src/main.c
@@ -31,12 +31,12 @@ static void lv_linux_disp_init(void)
 
 static void lv_linux_run_loop(void)
 {
-    uint32_t time_till_next;
+    uint32_t time_till_next_ms;
 
     /*Handle LVGL tasks*/
     while(1) {
-        time_till_next = lv_timer_handler();
-        usleep(time_till_next);
+        time_till_next_ms = lv_timer_handler();
+        usleep(time_till_next_ms * 1000);
     }
 }
 


### PR DESCRIPTION
Hi, while updating the Torizon OS docs for LVGL, I ran into this demo and found this small issue. It's not huge but will result on a higher CPU usage by not converting ms to us

I hope i'm not breaking any rules by opening this PR, let me know if I can be of more help