### PR TITLE
rustSlint: cargo: Disable debug symbols in dev profile

### DIFF
--- a/rustSlint/Cargo.toml
+++ b/rustSlint/Cargo.toml
@@ -9,5 +9,9 @@ build = "build.rs"
 [dependencies]
 slint = { version = "1.13.*", features = [ "backend-linuxkms-noseat", "renderer-skia" ] }
 
+[profile.dev.package."*"]
+opt-level = 3
+debug = 0
+
 [build-dependencies]
 slint-build = { version = "1.13.*" }


### PR DESCRIPTION
This will reduce the binary size considerably for debug builds. As the developer at first need the debug symbols to be present only for their own code, not for dependencies.

Also this will speed up remote sharing and deployment, as the binaries will be smaller, improving the remote development experience.

Fixes #387 