### PR TITLE
tasks/launch: Adjust flow to fix race condition for spin-down-tunnel

### DIFF
--- a/aspnetBlazor/.vscode/launch.json
+++ b/aspnetBlazor/.vscode/launch.json
@@ -46,7 +46,8 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-arm"
+            "preLaunchTask": "deploy-torizon-arm",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm64",
@@ -73,7 +74,8 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-arm64"
+            "preLaunchTask": "deploy-torizon-arm64",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon Browser ARMv8",
@@ -100,7 +102,8 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-browser-arm64"
+            "preLaunchTask": "deploy-torizon-browser-arm64",
+            "postDebugTask": "spin-down-tunnel"
         }
     ]
 }

--- a/assets/tasks/common.json
+++ b/assets/tasks/common.json
@@ -1618,11 +1618,9 @@
             ],
             "dependsOrder": "sequence",
             "dependsOn": [
-                "spin-down-tunnel",
                 "spin-up-tunnel",
                 "tunnel-check",
-                "pull-from-target-release",
-                "spin-down-tunnel"
+                "pull-from-target-release"
             ],
             "problemMatcher": "$tsc",
             "icon": {
@@ -1668,7 +1666,8 @@
                 "push-container-torizon-release",
                 "pull-container-torizon-release",
                 "template-specific-final-task",
-                "wait-a-bit"
+                "wait-a-bit",
+                "spin-down-tunnel"
             ],
             "problemMatcher": "$tsc",
             "icon": {
@@ -1716,7 +1715,8 @@
                 "push-container-torizon-release",
                 "pull-container-torizon-release",
                 "template-specific-final-task",
-                "wait-a-bit"
+                "wait-a-bit",
+                "spin-down-tunnel"
             ],
             "problemMatcher": "$tsc",
             "icon": {
@@ -1764,7 +1764,8 @@
                 "push-container-torizon-release",
                 "pull-container-torizon-release",
                 "template-specific-final-task",
-                "wait-a-bit"
+                "wait-a-bit",
+                "spin-down-tunnel"
             ],
             "problemMatcher": "$tsc",
             "icon": {

--- a/cLvgl/.vscode/tasks.json
+++ b/cLvgl/.vscode/tasks.json
@@ -588,7 +588,8 @@
             ],
             "dependsOrder": "sequence",
             "dependsOn": [
-                "stop-container-torizon"
+                "stop-container-torizon",
+                "spin-down-tunnel"
             ],
             "problemMatcher": "$msCompile",
             "icon": {

--- a/cmakeConsole/.vscode/launch.json
+++ b/cmakeConsole/.vscode/launch.json
@@ -71,7 +71,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm"
+            "preLaunchTask": "deploy-torizon-arm",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm64",
@@ -118,7 +119,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64"
+            "preLaunchTask": "deploy-torizon-arm64",
+            "postDebugTask": "spin-down-tunnel"
         }
     ]
 }

--- a/cmakeGTK3/.vscode/launch.json
+++ b/cmakeGTK3/.vscode/launch.json
@@ -71,7 +71,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-amd64"
+            "preLaunchTask": "deploy-torizon-amd64",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm32",
@@ -118,7 +119,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm"
+            "preLaunchTask": "deploy-torizon-arm",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm64",
@@ -165,7 +167,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64"
+            "preLaunchTask": "deploy-torizon-arm64",
+            "postDebugTask": "spin-down-tunnel"
         }
     ]
 }

--- a/cmakeGTK4/.vscode/launch.json
+++ b/cmakeGTK4/.vscode/launch.json
@@ -71,7 +71,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-amd64"
+            "preLaunchTask": "deploy-torizon-amd64",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm32",
@@ -118,7 +119,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm"
+            "preLaunchTask": "deploy-torizon-arm",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm64",
@@ -165,7 +167,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64"
+            "preLaunchTask": "deploy-torizon-arm64",
+            "postDebugTask": "spin-down-tunnel"
         }
     ]
 }

--- a/cppConsole/.vscode/launch.json
+++ b/cppConsole/.vscode/launch.json
@@ -71,7 +71,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-amd64"
+            "preLaunchTask": "deploy-torizon-amd64",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm32",
@@ -118,7 +119,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm"
+            "preLaunchTask": "deploy-torizon-arm",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm64",
@@ -165,7 +167,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64"
+            "preLaunchTask": "deploy-torizon-arm64",
+            "postDebugTask": "spin-down-tunnel"
         }
     ]
 }

--- a/cppQML/.vscode/launch.json
+++ b/cppQML/.vscode/launch.json
@@ -81,7 +81,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-amd64"
+            "preLaunchTask": "deploy-torizon-amd64",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm64",
@@ -137,7 +138,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64"
+            "preLaunchTask": "deploy-torizon-arm64",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm32",
@@ -193,7 +195,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm"
+            "preLaunchTask": "deploy-torizon-arm",
+            "postDebugTask": "spin-down-tunnel"
         }
     ]
 }

--- a/cppSlint/.vscode/launch.json
+++ b/cppSlint/.vscode/launch.json
@@ -71,7 +71,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-amd64"
+            "preLaunchTask": "deploy-torizon-amd64",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm64",
@@ -120,7 +121,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64"
+            "preLaunchTask": "deploy-torizon-arm64",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm32",
@@ -167,7 +169,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm"
+            "preLaunchTask": "deploy-torizon-arm",
+            "postDebugTask": "spin-down-tunnel"
         }
     ]
 }

--- a/dartFlutter/.vscode/launch.json
+++ b/dartFlutter/.vscode/launch.json
@@ -56,7 +56,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64"
+            "preLaunchTask": "deploy-torizon-arm64",
+            "postDebugTask": "spin-down-tunnel"
         }
     ]
 }

--- a/dotnetAvalonia/.vscode/launch.json
+++ b/dotnetAvalonia/.vscode/launch.json
@@ -39,7 +39,8 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-amd64"
+            "preLaunchTask": "deploy-torizon-amd64",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm32",
@@ -68,7 +69,8 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-arm"
+            "preLaunchTask": "deploy-torizon-arm",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm64",
@@ -97,7 +99,8 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-arm64"
+            "preLaunchTask": "deploy-torizon-arm64",
+            "postDebugTask": "spin-down-tunnel"
         }
     ]
 }

--- a/dotnetAvaloniaFrameBuffer/.vscode/tasks.json
+++ b/dotnetAvaloniaFrameBuffer/.vscode/tasks.json
@@ -232,7 +232,8 @@
             ],
             "dependsOrder": "sequence",
             "dependsOn": [
-                "stop-container-torizon-arm"
+                "stop-container-torizon-arm",
+                "spin-down-tunnel"
             ],
             "problemMatcher": "$msCompile",
             "icon": {
@@ -376,7 +377,8 @@
             ],
             "dependsOrder": "sequence",
             "dependsOn": [
-                "stop-container-torizon-arm64"
+                "stop-container-torizon-arm64",
+                "spin-down-tunnel"
             ],
             "problemMatcher": "$msCompile",
             "icon": {
@@ -574,7 +576,8 @@
             ],
             "dependsOrder": "sequence",
             "dependsOn": [
-                "stop-container-torizon-amd64"
+                "stop-container-torizon-amd64",
+                "spin-down-tunnel"
             ],
             "problemMatcher": "$msCompile",
             "icon": {

--- a/dotnetConsole/.vscode/launch.json
+++ b/dotnetConsole/.vscode/launch.json
@@ -37,7 +37,8 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-arm"
+            "preLaunchTask": "deploy-torizon-arm",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm64",
@@ -64,7 +65,8 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-arm64"
+            "preLaunchTask": "deploy-torizon-arm64",
+            "postDebugTask": "spin-down-tunnel"
         }
     ]
 }

--- a/genericTemplate/.vscode/tasks.json
+++ b/genericTemplate/.vscode/tasks.json
@@ -9,6 +9,10 @@
                 "id": "layers",
                 "color": "terminal.ansiCyan"
             },
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "spin-down-tunnel"
+            ],
             "presentation": {
                 "echo": false,
                 "reveal": "always",

--- a/multiRoot/multiRoot.code-workspace
+++ b/multiRoot/multiRoot.code-workspace
@@ -178,7 +178,8 @@
 					"build-container-torizon-release-arm",
 					"push-container-torizon-release",
 					"pull-container-torizon-release",
-					"wait-a-bit"
+					"wait-a-bit",
+					"spin-down-tunnel"
 				],
 				"presentation": {
 					"echo": true,
@@ -201,7 +202,8 @@
 					"build-container-torizon-release-arm64",
 					"push-container-torizon-release",
 					"pull-container-torizon-release",
-					"wait-a-bit"
+					"wait-a-bit",
+					"spin-down-tunnel"
 				],
 				"presentation": {
 					"echo": true,

--- a/nodeJSTypeScript/.vscode/launch.json
+++ b/nodeJSTypeScript/.vscode/launch.json
@@ -19,7 +19,8 @@
             "continueOnAttach": true,
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "${config:torizon_app_root}",
-            "preLaunchTask": "start-torizon-debug-amd64"
+            "preLaunchTask": "start-torizon-debug-amd64",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm32",
@@ -32,7 +33,8 @@
             "continueOnAttach": true,
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "${config:torizon_app_root}",
-            "preLaunchTask": "start-torizon-debug-arm"
+            "preLaunchTask": "start-torizon-debug-arm",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm64",
@@ -45,7 +47,8 @@
             "continueOnAttach": true,
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "${config:torizon_app_root}",
-            "preLaunchTask": "start-torizon-debug-arm64"
+            "preLaunchTask": "start-torizon-debug-arm64",
+            "postDebugTask": "spin-down-tunnel"
         }
     ]
 }

--- a/python3Console/.vscode/launch.json
+++ b/python3Console/.vscode/launch.json
@@ -23,7 +23,8 @@
                 "remoteRoot": "${config:torizon_app_root}"
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm"
+            "preLaunchTask": "deploy-torizon-arm",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm64",
@@ -40,7 +41,8 @@
                 "remoteRoot": "${config:torizon_app_root}"
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64"
+            "preLaunchTask": "deploy-torizon-arm64",
+            "postDebugTask": "spin-down-tunnel"
         }
     ]
 }

--- a/rustSlint/.vscode/launch.json
+++ b/rustSlint/.vscode/launch.json
@@ -83,7 +83,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-amd64"
+            "preLaunchTask": "deploy-torizon-amd64",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm32",
@@ -130,7 +131,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm"
+            "preLaunchTask": "deploy-torizon-arm",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm64",
@@ -177,7 +179,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64"
+            "preLaunchTask": "deploy-torizon-arm64",
+            "postDebugTask": "spin-down-tunnel"
         }
     ]
 }

--- a/zigConsole/.vscode/launch.json
+++ b/zigConsole/.vscode/launch.json
@@ -72,7 +72,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm"
+            "preLaunchTask": "deploy-torizon-arm",
+            "postDebugTask": "spin-down-tunnel"
         },
         {
             "name": "Torizon arm64",
@@ -119,7 +120,8 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64"
+            "preLaunchTask": "deploy-torizon-arm64",
+            "postDebugTask": "spin-down-tunnel"
         }
     ]
 }


### PR DESCRIPTION
spin-down-tunnel task can trigger race conditions on multi-root workspaces or when multiple debug sessions are started in parallel. This patch moves the spin-down-tunnel task to be a postDebugTask of each launch configuration and also adds it as the last task in the sequences that build and deploy containers to ensure that the tunnel is always spun down after all the operations are done.