### PR TITLE
tasks: use config instead of command for qt enterprise tasks

### DIFF
--- a/cppQML/.vscode/tasks.json
+++ b/cppQML/.vscode/tasks.json
@@ -848,8 +848,8 @@
             "options": {
                 "cwd": "${workspaceFolder}",
                 "env": {
-                    "QT_LICENSE_LOGIN": "${command:qt_license_login}",
-                    "QT_LICENSE_PASSWORD": "${command:qt_license_password}"
+                    "QT_LICENSE_LOGIN": "${config:qt_license_login}",
+                    "QT_LICENSE_PASSWORD": "${config:qt_license_password}"
                 }
             },
             "args": [
@@ -882,7 +882,7 @@
                 "cwd": "${workspaceFolder}",
                 "env": {
                     "QT_LICENSE_LOGIN": "${config:qt_license_login}",
-                    "QT_LICENSE_PASSWORD": "${command:qt_license_password}"
+                    "QT_LICENSE_PASSWORD": "${config:qt_license_password}"
                 }
             },
             "args": [


### PR DESCRIPTION
This is a fix for the qt enterprise tasks taking the property settings from the .code-workspace instead of settings.json in multiroot projects. This is needed because template specific settings are only set in settings.json

Related-to: TIE-1150