### PR TITLE
tasks/common/scripts: Add spin-up-down-registry xonsh script

### DIFF
--- a/aspnetBlazor/.vscode/launch.json
+++ b/aspnetBlazor/.vscode/launch.json
@@ -46,8 +46,7 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-arm",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm"
         },
         {
             "name": "Torizon arm64",
@@ -74,8 +73,7 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-arm64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm64"
         },
         {
             "name": "Torizon Browser ARMv8",
@@ -102,8 +100,7 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-browser-arm64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-browser-arm64"
         }
     ]
 }

--- a/assets/tasks/common.json
+++ b/assets/tasks/common.json
@@ -1190,13 +1190,12 @@
             "command": "${env:HOME}/.local/bin/xonsh",
             "type": "process",
             "args": [
-                "${workspaceFolder}/.conf/run-container-if-not-exists.xsh",
-                "--container-runtime",
-                "docker",
-                "--run-arguments",
-                "\"--rm -d --network host torizonextras/ide-port-tunnel:0.0.0 sshpass -p ${config:torizon_psswd} ssh -vv -N -R 5002:localhost:5002 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no ${config:torizon_login}@${config:torizon_ip}\"",
-                "--container-name",
-                "torizon-ide-port-tunnel"
+                "${workspaceFolder}/.conf/spin-up-down-registry.xsh",
+                "up",
+                "${config:torizon_psswd}",
+                "${config:torizon_login}",
+                "${config:torizon_ip}",
+                "${workspaceFolder}"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$tsc",
@@ -1274,13 +1273,15 @@
             "label": "spin-down-tunnel",
             "detail": "",
             "hide": true,
-            "command": "DOCKER_HOST=",
-            "type": "shell",
+            "command": "${env:HOME}/.local/bin/xonsh",
+            "type": "process",
             "args": [
-                "docker",
-                "rm",
-                "-f",
-                "torizon-ide-port-tunnel"
+                "${workspaceFolder}/.conf/spin-up-down-registry.xsh",
+                "down",
+                "${config:torizon_psswd}",
+                "${config:torizon_login}",
+                "${config:torizon_ip}",
+                "${workspaceFolder}"
             ],
             "dependsOrder": "sequence",
             "problemMatcher": "$tsc",

--- a/assets/tasks/common.json
+++ b/assets/tasks/common.json
@@ -94,9 +94,9 @@
             "type": "process",
             "options": {
                 "env": {
-                    "DOCKER_REGISTRY": "${command:inputBoxDockerRegistry}",
-                    "DOCKER_LOGIN": "${command:docker_login}",
-                    "DOCKER_PASSWORD": "${command:docker_password}",
+                    "DOCKER_REGISTRY": "${command:inputBox-docker_registry.__change__}",
+                    "DOCKER_LOGIN": "${command:docker_login.__change__}",
+                    "DOCKER_PASSWORD": "${command:docker_password.__change__}",
                     "TORIZON_ARCH": "${input:archList}",
                     "APP_ROOT": "${config:torizon_app_root}",
                     "DEBUG_SSH_PORT": "${config:torizon_debug_ssh_port}",
@@ -108,7 +108,7 @@
             "args": [
                 "${workspaceFolder}/.conf/create-docker-compose-production.xsh",
                 "${workspaceFolder}",
-                "${command:inputBoxDockerTag}",
+                "${command:inputBox-docker_tag.__change__}",
                 "__container__",
                 "${config:torizon_gpu}"
             ],
@@ -133,15 +133,15 @@
             "options": {
                 "cwd": "${workspaceFolder}",
                 "env": {
-                    "DOCKER_REGISTRY": "${command:inputBoxDockerRegistry}",
-                    "DOCKER_LOGIN": "${command:docker_login}",
-                    "DOCKER_PASSWORD": "${command:docker_password}",
-                    "DOCKER_TAG": "${command:inputBoxDockerTag}",
+                    "DOCKER_REGISTRY": "${command:inputBox-docker_registry.__change__}",
+                    "DOCKER_LOGIN": "${command:docker_login.__change__}",
+                    "DOCKER_PASSWORD": "${command:docker_password.__change__}",
+                    "DOCKER_TAG": "${command:inputBox-docker_tag.__change__}",
                     "TCB_CLIENTID": "${command:tcb.clientId}",
                     "TCB_CLIENTSECRET": "${command:tcb.clientSecret}",
                     "TCB_PACKAGE": "__change__",
                     "TCB_FLEET": "${command:tcb.fleetName}",
-                    "TORIZON_ARCH": "${command:torizon_arch}"
+                    "TORIZON_ARCH": "${command:torizon_arch.__change__}"
                 }
             },
             "args": [
@@ -219,9 +219,9 @@
             "options": {
                 "cwd": "${workspaceFolder}",
                 "env": {
-                    "DOCKER_PASSWORD": "${command:docker_password}",
-                    "DOCKER_LOGIN": "${command:docker_login}",
-                    "DOCKER_REGISTRY": "${command:inputBoxDockerRegistry}",
+                    "DOCKER_PASSWORD": "${command:docker_password.__change__}",
+                    "DOCKER_LOGIN": "${command:docker_login.__change__}",
+                    "DOCKER_REGISTRY": "${command:inputBox-docker_registry.__change__}",
                     "VSCODE_CMD": "--verbose platform push --credentials credentials.zip --package-name __change__ --package-version ${command:tcb.getNextPackageVersion} --login-to $DOCKER_REGISTRY $DOCKER_LOGIN $DOCKER_PASSWORD --force --canonicalize docker-compose.prod.yml"
                 }
             },
@@ -259,9 +259,9 @@
             "type": "shell",
             "options": {
                 "env": {
-                    "DOCKER_PASSWORD": "${command:docker_password}",
-                    "DOCKER_LOGIN": "${command:docker_login}",
-                    "DOCKER_REGISTRY": "${command:inputBoxDockerRegistry}"
+                    "DOCKER_PASSWORD": "${command:docker_password.__change__}",
+                    "DOCKER_LOGIN": "${command:docker_login.__change__}",
+                    "DOCKER_REGISTRY": "${command:inputBox-docker_registry.__change__}"
                 }
             },
             "args": [
@@ -526,7 +526,7 @@
                 "StrictHostKeyChecking=no",
                 "-o",
                 "PubkeyAuthentication=no",
-                "${command:torizon_workspace}/docker-compose.yml",
+                "${command:torizon_workspace.__change__}/docker-compose.yml",
                 "${config:torizon_login}@${config:torizon_ip}:~/"
             ],
             "dependsOrder": "sequence",
@@ -1865,10 +1865,10 @@
             "options": {
                 "cwd": "${workspaceFolder}",
                 "env": {
-                    "DOCKER_REGISTRY": "${command:inputBoxDockerRegistry}",
-                    "DOCKER_LOGIN": "${command:docker_login}",
-                    "DOCKER_PASSWORD": "${command:docker_password}",
-                    "DOCKER_TAG": "${command:inputBoxDockerTag}",
+                    "DOCKER_REGISTRY": "${command:inputBox-docker_registry.__change__}",
+                    "DOCKER_LOGIN": "${command:docker_login.__change__}",
+                    "DOCKER_PASSWORD": "${command:docker_password.__change__}",
+                    "DOCKER_TAG": "${command:inputBox-docker_tag.__change__}",
                     "TCB_CLIENTID": "${command:tcb.clientId}",
                     "TCB_CLIENTSECRET": "${command:tcb.clientSecret}",
                     "TCB_PACKAGE": "__change__",

--- a/assets/tasks/common.json
+++ b/assets/tasks/common.json
@@ -1619,9 +1619,11 @@
             ],
             "dependsOrder": "sequence",
             "dependsOn": [
+                "spin-down-tunnel",
                 "spin-up-tunnel",
                 "tunnel-check",
-                "pull-from-target-release"
+                "pull-from-target-release",
+                "spin-down-tunnel"
             ],
             "problemMatcher": "$tsc",
             "icon": {
@@ -1667,8 +1669,7 @@
                 "push-container-torizon-release",
                 "pull-container-torizon-release",
                 "template-specific-final-task",
-                "wait-a-bit",
-                "spin-down-tunnel"
+                "wait-a-bit"
             ],
             "problemMatcher": "$tsc",
             "icon": {
@@ -1716,8 +1717,7 @@
                 "push-container-torizon-release",
                 "pull-container-torizon-release",
                 "template-specific-final-task",
-                "wait-a-bit",
-                "spin-down-tunnel"
+                "wait-a-bit"
             ],
             "problemMatcher": "$tsc",
             "icon": {
@@ -1765,8 +1765,7 @@
                 "push-container-torizon-release",
                 "pull-container-torizon-release",
                 "template-specific-final-task",
-                "wait-a-bit",
-                "spin-down-tunnel"
+                "wait-a-bit"
             ],
             "problemMatcher": "$tsc",
             "icon": {

--- a/cLvgl/.vscode/tasks.json
+++ b/cLvgl/.vscode/tasks.json
@@ -588,8 +588,7 @@
             ],
             "dependsOrder": "sequence",
             "dependsOn": [
-                "stop-container-torizon",
-                "spin-down-tunnel"
+                "stop-container-torizon"
             ],
             "problemMatcher": "$msCompile",
             "icon": {

--- a/cmakeConsole/.vscode/launch.json
+++ b/cmakeConsole/.vscode/launch.json
@@ -71,8 +71,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm"
         },
         {
             "name": "Torizon arm64",
@@ -119,8 +118,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm64"
         }
     ]
 }

--- a/cmakeGTK3/.vscode/launch.json
+++ b/cmakeGTK3/.vscode/launch.json
@@ -71,8 +71,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-amd64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-amd64"
         },
         {
             "name": "Torizon arm32",
@@ -119,8 +118,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm"
         },
         {
             "name": "Torizon arm64",
@@ -167,8 +165,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm64"
         }
     ]
 }

--- a/cmakeGTK4/.vscode/launch.json
+++ b/cmakeGTK4/.vscode/launch.json
@@ -71,8 +71,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-amd64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-amd64"
         },
         {
             "name": "Torizon arm32",
@@ -119,8 +118,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm"
         },
         {
             "name": "Torizon arm64",
@@ -167,8 +165,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm64"
         }
     ]
 }

--- a/cppConsole/.vscode/launch.json
+++ b/cppConsole/.vscode/launch.json
@@ -71,8 +71,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-amd64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-amd64"
         },
         {
             "name": "Torizon arm32",
@@ -119,8 +118,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm"
         },
         {
             "name": "Torizon arm64",
@@ -167,8 +165,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm64"
         }
     ]
 }

--- a/cppQML/.vscode/launch.json
+++ b/cppQML/.vscode/launch.json
@@ -81,8 +81,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-amd64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-amd64"
         },
         {
             "name": "Torizon arm64",
@@ -138,8 +137,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm64"
         },
         {
             "name": "Torizon arm32",
@@ -195,8 +193,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm"
         }
     ]
 }

--- a/cppSlint/.vscode/launch.json
+++ b/cppSlint/.vscode/launch.json
@@ -71,8 +71,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-amd64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-amd64"
         },
         {
             "name": "Torizon arm64",
@@ -121,8 +120,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm64"
         },
         {
             "name": "Torizon arm32",
@@ -169,8 +167,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm"
         }
     ]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -94,7 +94,8 @@
         "Devs",
         "wbem",
         "depok",
-        "repr"
+        "repr",
+        "torizonextras"
     ],
     "import": [],
     "languageSettings": [

--- a/dartFlutter/.vscode/launch.json
+++ b/dartFlutter/.vscode/launch.json
@@ -56,8 +56,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm64"
         }
     ]
 }

--- a/dotnetAvalonia/.vscode/launch.json
+++ b/dotnetAvalonia/.vscode/launch.json
@@ -39,8 +39,7 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-amd64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-amd64"
         },
         {
             "name": "Torizon arm32",
@@ -69,8 +68,7 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-arm",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm"
         },
         {
             "name": "Torizon arm64",
@@ -99,8 +97,7 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-arm64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm64"
         }
     ]
 }

--- a/dotnetAvaloniaFrameBuffer/.vscode/tasks.json
+++ b/dotnetAvaloniaFrameBuffer/.vscode/tasks.json
@@ -232,8 +232,7 @@
             ],
             "dependsOrder": "sequence",
             "dependsOn": [
-                "stop-container-torizon-arm",
-                "spin-down-tunnel"
+                "stop-container-torizon-arm"
             ],
             "problemMatcher": "$msCompile",
             "icon": {
@@ -377,8 +376,7 @@
             ],
             "dependsOrder": "sequence",
             "dependsOn": [
-                "stop-container-torizon-arm64",
-                "spin-down-tunnel"
+                "stop-container-torizon-arm64"
             ],
             "problemMatcher": "$msCompile",
             "icon": {
@@ -576,8 +574,7 @@
             ],
             "dependsOrder": "sequence",
             "dependsOn": [
-                "stop-container-torizon-amd64",
-                "spin-down-tunnel"
+                "stop-container-torizon-amd64"
             ],
             "problemMatcher": "$msCompile",
             "icon": {

--- a/dotnetConsole/.vscode/launch.json
+++ b/dotnetConsole/.vscode/launch.json
@@ -37,8 +37,7 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-arm",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm"
         },
         {
             "name": "Torizon arm64",
@@ -65,8 +64,7 @@
                 ],
                 "debuggerPath": "/vsdbg/vsdbg"
             },
-            "preLaunchTask": "deploy-torizon-arm64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm64"
         }
     ]
 }

--- a/genericTemplate/.vscode/tasks.json
+++ b/genericTemplate/.vscode/tasks.json
@@ -9,10 +9,6 @@
                 "id": "layers",
                 "color": "terminal.ansiCyan"
             },
-            "dependsOrder": "sequence",
-            "dependsOn": [
-                "spin-down-tunnel"
-            ],
             "presentation": {
                 "echo": false,
                 "reveal": "always",

--- a/multiRoot/multiRoot.code-workspace
+++ b/multiRoot/multiRoot.code-workspace
@@ -178,8 +178,7 @@
 					"build-container-torizon-release-arm",
 					"push-container-torizon-release",
 					"pull-container-torizon-release",
-					"wait-a-bit",
-					"spin-down-tunnel"
+					"wait-a-bit"
 				],
 				"presentation": {
 					"echo": true,
@@ -202,8 +201,7 @@
 					"build-container-torizon-release-arm64",
 					"push-container-torizon-release",
 					"pull-container-torizon-release",
-					"wait-a-bit",
-					"spin-down-tunnel"
+					"wait-a-bit"
 				],
 				"presentation": {
 					"echo": true,

--- a/multiRoot/multiRoot.code-workspace
+++ b/multiRoot/multiRoot.code-workspace
@@ -73,9 +73,9 @@
 				],
 				"options": {
 					"env": {
-						"DOCKER_REGISTRY": "${command:inputBoxDockerRegistry}",
-						"DOCKER_LOGIN": "${command:docker_login}",
-						"DOCKER_PASSWORD": "${command:docker_password}",
+						"DOCKER_REGISTRY": "${command:inputBox-docker_registry.__change__}",
+						"DOCKER_LOGIN": "${command:docker_login.__change__}",
+						"DOCKER_PASSWORD": "${command:docker_password.__change__}",
 						"TORIZON_ARCH": "${input:archList}",
 						"APP_ROOT": "${config:torizon_app_root}"
 					}

--- a/nodeJSTypeScript/.vscode/launch.json
+++ b/nodeJSTypeScript/.vscode/launch.json
@@ -19,8 +19,7 @@
             "continueOnAttach": true,
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "${config:torizon_app_root}",
-            "preLaunchTask": "start-torizon-debug-amd64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "start-torizon-debug-amd64"
         },
         {
             "name": "Torizon arm32",
@@ -33,8 +32,7 @@
             "continueOnAttach": true,
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "${config:torizon_app_root}",
-            "preLaunchTask": "start-torizon-debug-arm",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "start-torizon-debug-arm"
         },
         {
             "name": "Torizon arm64",
@@ -47,8 +45,7 @@
             "continueOnAttach": true,
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "${config:torizon_app_root}",
-            "preLaunchTask": "start-torizon-debug-arm64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "start-torizon-debug-arm64"
         }
     ]
 }

--- a/python3Console/.vscode/launch.json
+++ b/python3Console/.vscode/launch.json
@@ -23,8 +23,7 @@
                 "remoteRoot": "${config:torizon_app_root}"
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm"
         },
         {
             "name": "Torizon arm64",
@@ -41,8 +40,7 @@
                 "remoteRoot": "${config:torizon_app_root}"
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm64"
         }
     ]
 }

--- a/rustSlint/.vscode/launch.json
+++ b/rustSlint/.vscode/launch.json
@@ -83,8 +83,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-amd64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-amd64"
         },
         {
             "name": "Torizon arm32",
@@ -131,8 +130,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm"
         },
         {
             "name": "Torizon arm64",
@@ -179,8 +177,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm64"
         }
     ]
 }

--- a/scripts/bash/setup-xonsh.sh
+++ b/scripts/bash/setup-xonsh.sh
@@ -28,7 +28,7 @@ if [ -f "$HOME/.local/bin/xonsh" ]; then
     ref="$branch"
     fi
 
-    pipx runpip xonsh install --upgrade "git+${repo}@${ref}#subdirectory=scripts/utils/pip"
+    pipx runpip xonsh install --force-reinstall "git+${repo}@${ref}#subdirectory=scripts/utils/pip"
 
     echo "all ok ✅"
     exit 0

--- a/scripts/build-multi-root.xsh
+++ b/scripts/build-multi-root.xsh
@@ -23,6 +23,13 @@ obj_rec = json.loads(args[2])
 project_name = obj_rec["Name"]
 project_folder = location_folder_join
 
+ENV_MERGE_MAP = {
+    "create-image-production-all": {
+        "env_name": "DOCKER_TAG",
+        "env_value": "inputBox-docker_tag"
+    }
+}
+
 # Compose path
 compose_path = project_folder / "docker-compose.yml"
 compose_template_path = home / ".apollox" / "empty" / "docker-compose.yml"
@@ -136,6 +143,19 @@ for task in code_workspace.get("tasks", {}).get("tasks", []):
         cwd = task["options"].get("cwd")
         if isinstance(cwd, str):
             task["options"]["cwd"] = cwd.replace("${workspaceFolder}", f"${{workspaceFolder:{project_name}}}")
+    
+    label = task["label"]
+    if label in ENV_MERGE_MAP:
+        env_info = ENV_MERGE_MAP[label]
+        env_name = env_info["env_name"]
+        env_value = env_info["env_value"]
+
+        for template in obj_rec["Projects"]:
+            template_name = template["Name"]
+            if template_name != project_name:
+                if "env" not in task["options"] or not isinstance(task["options"]["env"], dict):
+                    task["options"]["env"] = {}
+                task["options"]["env"][f"{env_name}_{template_name}"] = f"${{command:{env_value}.{template_name}}}"
 
 # Save updated files
 with open(compose_path, "w") as f:

--- a/scripts/create-from-template.xsh
+++ b/scripts/create-from-template.xsh
@@ -272,6 +272,7 @@ if template_scripts is None:
     cp -r @(template_folder)/../scripts/apply-ci-settings-file.xsh @(new_project_path)/.conf/
     cp -r @(template_folder)/../scripts/validate-json.xsh @(new_project_path)/.conf/
     cp -r @(template_folder)/../scripts/service-check.xsh @(new_project_path)/.conf/
+    cp -r @(template_folder)/../scripts/spin-up-down-registry.xsh @(new_project_path)/.conf/
 else:
     for script in template_scripts:
         cp -r @(os.path.join(template_folder, "..", "scripts", script)) @(os.path.join(new_project_path, ".conf"))

--- a/scripts/spin-up-down-registry.xsh
+++ b/scripts/spin-up-down-registry.xsh
@@ -1,0 +1,140 @@
+#!/usr/bin/env xonsh
+
+# Copyright (c) 2025 Toradex
+# SPDX-License-Identifier: MIT
+
+##
+# This script is used to manage race conditions when spinning up and down
+# the torizon-ide-port-tunnel container.
+##
+
+# use the xonsh environment to update the OS environment
+$UPDATE_OS_ENVIRON = True
+# Get the full log of error
+$XONSH_SHOW_TRACEBACK = True
+# always return if a cmd fails
+$RAISE_SUBPROC_ERROR = True
+
+
+import os
+import sys
+import fcntl
+from torizon_templates_utils.args import get_arg_not_empty,get_optional_arg
+from torizon_templates_utils.errors import Error,Error_Out
+
+
+def _plus_locker(workspace) :
+    # read or create the .conf/.registry_locker file
+    locker_file = os.path.join(
+        "/tmp",
+        ".apollox-registry_locker"
+    )
+
+    # Use exclusive lock to prevent race conditions
+    with open(locker_file, "a+") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            f.seek(0)
+            lines = f.readlines()
+
+            # Parse existing workspace entries
+            workspaces = set()
+            for line in lines:
+                line = line.strip()
+                if line:
+                    workspaces.add(line)
+
+            # Add workspace if not already present
+            if workspace not in workspaces:
+                workspaces.add(workspace)
+
+            # Write back all workspaces
+            f.seek(0)
+            f.truncate()
+            for ws_name in workspaces:
+                f.write(f"{ws_name}\n")
+            f.flush()
+
+            return len(workspaces)
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+def _minus_locker(workspace) :
+    # read or create the .conf/.registry_locker file
+    locker_file = os.path.join(
+        "/tmp",
+        ".apollox-registry_locker"
+    )
+
+    # Use exclusive lock to prevent race conditions
+    with open(locker_file, "a+") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            f.seek(0)
+            lines = f.readlines()
+
+            # Parse existing workspace entries
+            workspaces = set()
+            for line in lines:
+                line = line.strip()
+                if line:
+                    workspaces.add(line)
+
+            # Remove workspace if present
+            if workspace in workspaces:
+                workspaces.remove(workspace)
+
+            # Write back remaining workspaces
+            f.seek(0)
+            f.truncate()
+            for ws_name in workspaces:
+                f.write(f"{ws_name}\n")
+            f.flush()
+
+            return len(workspaces)
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+if len(sys.argv) != 6:
+    Error_Out(
+        f"Error: Expected 6 argument, but got {len(sys.argv) -1}.\n" +
+        "Report on https://github.com/torizon/vscode-torizon-templates/issues",
+        Error.EINVAL
+    )
+
+action = get_arg_not_empty(1)
+psswd = get_arg_not_empty(2)
+login = get_optional_arg(3)
+ip = get_optional_arg(4)
+workspace = get_arg_not_empty(5)
+
+if action not in ["up","down"]:
+    Error_Out(
+        f"Error: Invalid argument '{action}'. Expected 'up' or 'down'.\n" +
+        "Report on https://github.com/torizon/vscode-torizon-templates/issues",
+        Error.EINVAL
+    )
+
+if action == "up":
+    _plus_locker(workspace)
+
+    $HOME/.local/bin/xonsh ./.conf/run-container-if-not-exists.xsh \
+        --container-runtime docker \
+        --run-arguments \
+        @(f"\"--rm -d --network host torizonextras/ide-port-tunnel:0.0.0 sshpass -p {psswd} ssh -vv -N -R 5002:localhost:5002 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no {login}@{ip}\"") \
+        --container-name \
+        torizon-ide-port-tunnel
+
+    sys.exit(0)
+
+
+if action == "down":
+    count = _minus_locker(workspace)
+
+    # just remove the container if no one is using it
+    if count == 0:
+        DOCKER_HOST= docker rm -f torizon-ide-port-tunnel
+
+    sys.exit(0)

--- a/scripts/utils/pip/torizon_templates_utils/tasks.py
+++ b/scripts/utils/pip/torizon_templates_utils/tasks.py
@@ -23,9 +23,9 @@ def replace_tasks_input():
                 with open(file, 'r') as f:
                     content = f.read()
 
-                content = content.replace("input:dockerLogin", "command:docker_login")
-                content = content.replace("input:dockerImageRegistry", "command:inputBoxDockerRegistry")
-                content = content.replace("input:dockerPsswd", "command:docker_password")
+                content = content.replace("input:dockerLogin", "command:docker_login.__change__")
+                content = content.replace("input:dockerImageRegistry", "command:inputBox-docker_registry.__change__")
+                content = content.replace("input:dockerPsswd", "command:docker_password.__change__")
 
                 with open(file, 'w') as f:
                     f.write(content)
@@ -576,6 +576,28 @@ class TaskRunner:
         return ret
 
 
+    def __check_input_boxes(self, env: List[str]) -> List[str]:
+        ret: List[str] = []
+
+        for value in env:
+            value = value.replace("${command:inputBox-", "${config:")
+            ret.append(value)
+
+        return ret
+
+
+    def __check_cmd_args(self, env: List[str]) -> List[str]:
+        ret: List[str] = []
+
+        for value in env:
+            # This will strip the workspace from the command
+            # For example command:inputBox.qt will be turned into command:inputBox
+            value = value.split(".", 1)[0]
+            ret.append(value)
+
+        return ret
+
+
     def __check_docker_inputs(self, env: List[str]) -> List[str]:
         ret: List[str] = []
 
@@ -828,6 +850,7 @@ class TaskRunner:
             if _env_value:
                 expvalue = [_env_value]
                 expvalue = self.__check_workspace_folder(expvalue)
+                expvalue = self.__check_input_boxes(expvalue)
                 expvalue = self.__check_torizon_inputs(expvalue)
                 expvalue = self.__check_docker_inputs(expvalue)
                 expvalue = self.__check_tcb_inputs(expvalue)
@@ -888,7 +911,9 @@ class TaskRunner:
         _cmd = _task.command
 
         # the cmd itself can use the mechanism to replace stuff
+        _cmd = self.__check_cmd_args([_cmd])[0]
         _cmd = self.__check_workspace_folder([_cmd])[0]
+        _cmd = self.__check_input_boxes([_cmd])[0]
         _cmd = self.__check_torizon_inputs([_cmd])[0]
         _cmd = self.__check_docker_inputs([_cmd])[0]
         _cmd = self.__check_tcb_inputs([_cmd])[0]
@@ -917,6 +942,7 @@ class TaskRunner:
         #           but when used on Python it generates weird behavior
         # _args = self.__scape_args(_args)
         _args = self.__check_workspace_folder(_args)
+        _args = self.__check_input_boxes(_args)
         _args = self.__check_torizon_inputs(_args)
         _args = self.__check_docker_inputs(_args)
         _args = self.__check_tcb_inputs(_args)

--- a/scripts/utils/replaceTasksInput.ps1
+++ b/scripts/utils/replaceTasksInput.ps1
@@ -16,21 +16,21 @@ function Replace-Tasks-Input () {
                     ForEach-Object {
                         $_ -replace `
                         "input:dockerLogin", `
-                        "command:docker_login"
+                        "command:docker_login.__change__"
                     } | Set-Content $a
 
                     ( Get-Content $a ) |
                     ForEach-Object {
                         $_ -replace `
                         "input:dockerImageRegistry", `
-                        "command:inputBoxDockerRegistry"
+                        "command:inputBox-docker_registry.__change__"
                     } | Set-Content $a
 
                     ( Get-Content $a ) |
                     ForEach-Object {
                         $_ -replace `
                         "input:dockerPsswd", `
-                        "command:docker_password"
+                        "command:docker_password.__change__"
                     } | Set-Content $a
                 }
             }

--- a/zigConsole/.vscode/launch.json
+++ b/zigConsole/.vscode/launch.json
@@ -72,8 +72,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm"
         },
         {
             "name": "Torizon arm64",
@@ -120,8 +119,7 @@
                     "ignoreFailures": true
                 }
             ],
-            "preLaunchTask": "deploy-torizon-arm64",
-            "postDebugTask": "spin-down-tunnel"
+            "preLaunchTask": "deploy-torizon-arm64"
         }
     ]
 }


### PR DESCRIPTION
For multi-container projects the spin down of the torizon-ide-port-tunnel
container could lead to race conditions where one task spins down the
container while another task is trying to spin it up or using it.
To avoid this we introduce a locker mechanism in a new script
spin-up-down-registry.xsh that will keep track of how many tasks
are using the container and only spin it down when no task is using it.

Signed-off-by: Matheus Castello <matheus@castello.eng.br>