### PR TITLE
scripts: create-from-template: Fix telemetry API request

### DIFF
--- a/cppQML/.vscode/tasks.json
+++ b/cppQML/.vscode/tasks.json
@@ -394,7 +394,7 @@
             "type": "shell",
             "options": {
                 "env": {
-                    "QT_LICENSE_LOGIN": "${config:qt_license_login}",
+                    "QT_LICENSE_LOGIN": "${command:qt_license_login.__change__}",
                     "QT_LICENSE_PASSWORD": "${command:qt_license_password.__change__}"
                 }
             },

--- a/scripts/create-from-template.xsh
+++ b/scripts/create-from-template.xsh
@@ -138,12 +138,11 @@ if telemetry:
         _query = urllib.parse.urlencode({
             "template": template,
             "dateTime": date.today().isoformat()
-        }).encode("utf-8")
+        })
 
         _conn = http.client.HTTPConnection("ec2-3-133-114-116.us-east-2.compute.amazonaws.com")
         _conn.request(
-            "GET", "/api/template/plus",
-            body=_query
+            "GET", f"/api/Template/plus?{_query}"
         )
 
         _res = _conn.getresponse()


### PR DESCRIPTION
It seems that this was broken since the change from PWSH to XSH. The endpoint is case sensitive and the parameters should be sent as query strings in a GET request, not in the body.