### PR TITLE
scripts: containers: Fix utils and dev container versioning

### DIFF
--- a/scripts/bash/tcd-env-setup.sh
+++ b/scripts/bash/tcd-env-setup.sh
@@ -6,7 +6,8 @@ __TCD_COMPOSE_FILE="$HOME/.tcd/docker-compose.yml"
 __TCD_BASH_COMPLETION_FILE="$HOME/.tcd/torizon-dev-completion.bash"
 export __TCD_APOLLOX_REPO="torizon/vscode-torizon-templates"
 export __TCD_APOLLOX_BRANCH="dev"
-export __TCD_BRANCH="dev"
+# ⚠️ THIS NEED TO BE IN SYNC WITH THE PYTHON UTILS VERSION
+export __TCD_BRANCH="1.1.0"
 export __TCD_UUID=$(id -u)
 export __TCD_DGID=$(getent group docker | cut -d: -f3)
 

--- a/scripts/build-internal-containers.xsh
+++ b/scripts/build-internal-containers.xsh
@@ -28,6 +28,8 @@ if len(sys.argv) != 2:
 
 $__TCD_BRANCH = sys.argv[1]
 $__TCD_SHA_DIR = 0
+# ⚠️ THIS NEED TO BE IN SYNC WITH THE PYTHON UTILS VERSION
+$__UTILS_VERSION = "1.1.0"
 
 # # run the build command
 print(f"🔨 :: XONSH :: 🔨", color=Color.GREEN)
@@ -38,6 +40,11 @@ docker compose \
     --push \
     xonsh
 
+# rename for have the one with the right tag
+docker tag \
+    torizonextras/xonsh:${__TCD_BRANCH} \
+    torizonextras/xonsh:${__UTILS_VERSION}
+
 # # run the build command
 print(f"🔨 :: TASKS :: 🔨", color=Color.GREEN)
 docker compose \
@@ -46,6 +53,11 @@ docker compose \
     --no-cache \
     --push \
     tasks
+
+# create a copy with the right versioning tag
+docker tag \
+    torizonextras/torizon-dev-tasks:${__TCD_BRANCH} \
+    torizonextras/torizon-dev-tasks:${__UTILS_VERSION}
 
 # # run the build command
 print(f"🔨 :: XONSH-WRAPPER :: 🔨", color=Color.GREEN)
@@ -56,6 +68,11 @@ docker compose \
     --push \
     xonsh-wrapper
 
+# rename for have the one with the right tag
+docker tag \
+    torizonextras/xonsh-wrapper:${__TCD_BRANCH} \
+    torizonextras/xonsh-wrapper:${__UTILS_VERSION}
+
 # run the build command
 print(f"🔨 :: TORIZON-DEV :: 🔨", color=Color.GREEN)
 docker compose \
@@ -64,6 +81,11 @@ docker compose \
     --no-cache \
     --push \
     torizon-dev
+
+# rename for have the one with the right tag
+docker tag \
+    torizonextras/torizon-dev:${__TCD_BRANCH} \
+    torizonextras/torizon-dev:${__UTILS_VERSION}
 
 # run the build command
 print(f"🔨 :: SSH-TUNNEL :: 🔨", color=Color.GREEN)

--- a/scripts/utils/pip/pyproject.toml
+++ b/scripts/utils/pip/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torizon_templates_utils"
-version = "1.0.0"
+version = "1.1.0"
 authors = [
   { name="Matheus Castello", email="matheus.castello@toradex.com" },
 ]


### PR DESCRIPTION
Today we are publishing everything as dev what is very bad for maintenance and versioning. Let's fix that by setting a proper version for the utils and tagging the containers with it.