### PR TITLE
templates: tasks.json: Remove "hide: true" from tasks that run on folderOpen

### DIFF
--- a/cLvgl/.vscode/tasks.json
+++ b/cLvgl/.vscode/tasks.json
@@ -6,7 +6,6 @@
             "runOptions": {
                 "runOn": "folderOpen"
             },
-            "hide": true,
             "command": "git",
             "type": "shell",
             "args": [

--- a/dotnetAvalonia/.vscode/tasks.json
+++ b/dotnetAvalonia/.vscode/tasks.json
@@ -3,7 +3,6 @@
     "tasks": [
         {
             "label": "create-preview-assets",
-            "hide": true,
             "command": "${command:avalonia.createPreviewerAssets}",
             "type": "process",
             "isBuildCommand": true,

--- a/dotnetAvaloniaFrameBuffer/.vscode/tasks.json
+++ b/dotnetAvaloniaFrameBuffer/.vscode/tasks.json
@@ -3,7 +3,6 @@
     "tasks": [
         {
             "label": "create-preview-assets",
-            "hide": true,
             "command": "${command:avalonia.createPreviewerAssets}",
             "type": "process",
             "isBuildCommand": true,

--- a/python3Console/.vscode/tasks.json
+++ b/python3Console/.vscode/tasks.json
@@ -4,7 +4,6 @@
         {
             "label": "create-prepare-venv",
             "detail": "",
-            "hide": true,
             "command": "echo",
             "type": "process",
             "args": [

--- a/tcb/.vscode/tasks.json
+++ b/tcb/.vscode/tasks.json
@@ -35,7 +35,6 @@
         {
             "label": "tcb-setup",
             "detail": "",
-            "hide": true,
             "command": "DOCKER_HOST=",
             "type": "shell",
             "runOptions": {
@@ -479,4 +478,3 @@
     ],
     "inputs": []
 }
-


### PR DESCRIPTION
This is done because some users may not have allowAutomaticTasks enabled and in that case these tasks would never run and not be visible for the run to run manually either.

Related-to: TIE-1223