### PR TITLE
Fix ssh-check task

### DIFF
--- a/assets/tasks/common.json
+++ b/assets/tasks/common.json
@@ -1253,7 +1253,7 @@
                 "ssh",
                 "'${config:torizon_psswd}'",
                 "${config:torizon_debug_ssh_port}",
-                "${config:torizon_login}",
+                "${config:torizon_run_as}",
                 "${config:torizon_ip}",
                 "echo ssh-ok"
             ],


### PR DESCRIPTION
It connects inside the container and inside the container we run as `$config:torizon_run_as` and not as `$config:torizon_login` which is the login to the host OS.

It accidentally worked for others because I'm probably the only soul in the universe that runs my application as a different user than "torizon".