### PR TITLE
scripts: bash: setup-xonsh: Add a check to link xonsh globally if needed

### DIFF
--- a/scripts/bash/setup-xonsh.sh
+++ b/scripts/bash/setup-xonsh.sh
@@ -2,7 +2,47 @@
 
 echo "🐚 SETUP XONSH"
 
-# check if xonsh is on $HHOME/.local/bin
+function _check_xonsh_global {
+    # we need to check if we need to run the setup as root
+    # at the first time we should need to symlink the xonsh to the /usr/bin
+    # read the /usr/bin/xonsh and check if it is linked to the
+    # $HOME/.local/bin/xonsh, if not we need to run with sudo
+    local local_xonsh="$HOME/.local/bin/xonsh"
+    local global_xonsh="/usr/bin/xonsh"
+
+    if [ ! -f "$local_xonsh" ]; then
+        echo "Expected local xonsh at $local_xonsh but it was not found."
+        return 1
+    fi
+
+    if [ -e "$global_xonsh" ] && [ "$(readlink -f "$global_xonsh")" = "$local_xonsh" ]; then
+        return 0
+    fi
+
+    if [ -e "$global_xonsh" ]; then
+        echo "The xonsh in $global_xonsh is not linked to $local_xonsh, trying to relink ..."
+    else
+        echo "$global_xonsh does not exist, creating global xonsh link ..."
+    fi
+
+    if ln -sf "$local_xonsh" "$global_xonsh" 2>/dev/null; then
+        return 0
+    fi
+
+    if [ -z "${PSSWD}" ]; then
+        echo "Insufficient permissions to create $global_xonsh and PSSWD is not set."
+        return 1
+    fi
+
+    if ! printf '%s\n' "$PSSWD" | sudo -S ln -sf "$local_xonsh" "$global_xonsh"; then
+        echo "Failed to create $global_xonsh using sudo. Check password and sudo permissions."
+        return 1
+    fi
+
+    return 0
+}
+
+# check if xonsh is on $HOME/.local/bin
 if [ -f "$HOME/.local/bin/xonsh" ]; then
     echo "xonsh is already installed, updating torizon-templates-utils ..."
 
@@ -40,6 +80,11 @@ if [ -f "$HOME/.local/bin/xonsh" ]; then
     echo "Using published package..."
     pipx runpip xonsh install --upgrade torizon-templates-utils
 
+    # re-check if we need to link xonsh globally
+    if ! _check_xonsh_global; then
+        exit 1
+    fi
+
     echo "all ok ✅"
     exit 0
 fi
@@ -69,4 +114,9 @@ if [ ! -f ~/.xonshrc ]; then
 fi
 if ! grep -q "\$HOME/.local/bin" ~/.xonshrc; then
     echo "\$PATH.insert(0, '$HOME/.local/bin')" >> ~/.xonshrc
+fi
+
+# also make sure the xonsh is linked to the /usr/bin
+if ! _check_xonsh_global; then
+    exit 1
 fi


### PR DESCRIPTION
first of all we need to check if we need to run the setup as root at the first time we should need to symlink the xonsh to the /usr/bin and for this we need administrative privileges,
after the first setup we can run it without sudo to update it read the /usr/bin/xonsh and check if it is linked to the $HOME/.local/bin/xonsh, if not we need to run with sudo