### PR TITLE
Slint: Upgrade to 1.16.1

### DIFF
--- a/cppSlint/Dockerfile
+++ b/cppSlint/Dockerfile
@@ -28,7 +28,7 @@ ARG GPU=
 ##
 # Slint Version
 ##
-ARG SLINT_VERSION=1.13.1
+ARG SLINT_VERSION=1.16.1
 
 # BUILD ------------------------------------------------------------------------
 FROM --platform=linux/${HOST_ARCH} torizon/cross-toolchain-${IMAGE_ARCH}:${CROSS_SDK_BASE_TAG} AS build
@@ -94,6 +94,7 @@ RUN \
     apt-get update && \
     apt-get install --assume-yes \
     pkg-config \
+    libfontconfig1 \
     libfontconfig1-dev:$CROSS_TOOLCHAIN_ARCH \
     libxcb1-dev:$CROSS_TOOLCHAIN_ARCH \
     libxcb-render0-dev:$CROSS_TOOLCHAIN_ARCH \

--- a/cppSlint/Dockerfile.debug
+++ b/cppSlint/Dockerfile.debug
@@ -32,7 +32,7 @@ ARG GPU=
 ##
 # Slint Version
 ##
-ARG SLINT_VERSION=1.13.1
+ARG SLINT_VERSION=1.16.1
 
 ##
 # Deploy Step

--- a/cppSlint/Dockerfile.sdk
+++ b/cppSlint/Dockerfile.sdk
@@ -27,7 +27,7 @@ ARG APP_ROOT=
 ##
 # Slint Version
 ##
-ARG SLINT_VERSION=1.13.1
+ARG SLINT_VERSION=1.16.1
 
 # BUILD ------------------------------------------------------------------------
 FROM --platform=linux/${HOST_ARCH} torizon/cross-toolchain-${IMAGE_ARCH}:${CROSS_SDK_BASE_TAG} AS build
@@ -88,6 +88,7 @@ RUN \
     apt-get update && \
     apt-get install --assume-yes \
     pkg-config \
+    libfontconfig1 \
     libfontconfig1-dev:$CROSS_TOOLCHAIN_ARCH \
     libxcb1-dev:$CROSS_TOOLCHAIN_ARCH \
     libxcb-render0-dev:$CROSS_TOOLCHAIN_ARCH \

--- a/rustSlint/Cargo.toml
+++ b/rustSlint/Cargo.toml
@@ -7,11 +7,11 @@ build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-slint = { version = "1.13.*", features = [ "backend-linuxkms-noseat", "renderer-skia" ] }
+slint = { version = "1.16.*", features = [ "backend-linuxkms-noseat", "renderer-skia" ] }
 
 [profile.dev.package."*"]
 opt-level = 3
 debug = 0
 
 [build-dependencies]
-slint-build = { version = "1.13.*" }
+slint-build = { version = "1.16.*" }

--- a/rustSlint/Dockerfile
+++ b/rustSlint/Dockerfile
@@ -98,9 +98,6 @@ RUN apt-get -q -y update && \
     rm -rf /var/lib/apt/lists/*
 # __deps__
 
-# Don't require font-config when the compiler runs
-ENV RUST_FONTCONFIG_DLOPEN=on
-
 COPY . ${APP_ROOT}
 WORKDIR ${APP_ROOT}
 

--- a/rustSlint/Dockerfile.sdk
+++ b/rustSlint/Dockerfile.sdk
@@ -98,9 +98,6 @@ RUN apt-get -q -y update && \
     apt-get clean && apt-get autoremove && \
     rm -rf /var/lib/apt/lists/*
 
-# Don't require font-config when the compiler runs
-ENV RUST_FONTCONFIG_DLOPEN=on
-
 # Default to the Skia backend for best performance
 ENV SLINT_BACKEND=linuxkms-skia
 # Default to Slint running in fullscreen


### PR DESCRIPTION
These two commits upgrade the Slint C++ and Rust template to the latest release.