### PR TITLE
github/actions: Fix node 20 deprecation warning

### DIFF
--- a/.github/workflows/build-ccpp.yaml
+++ b/.github/workflows/build-ccpp.yaml
@@ -23,7 +23,7 @@ jobs:
             vendor: '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/build-debug-ccpp.yaml
+++ b/.github/workflows/build-debug-ccpp.yaml
@@ -23,7 +23,7 @@ jobs:
             vendor: '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/build-debug-dotnet.yaml
+++ b/.github/workflows/build-debug-dotnet.yaml
@@ -24,7 +24,7 @@ jobs:
             vendor:  '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/build-debug-python.yaml
+++ b/.github/workflows/build-debug-python.yaml
@@ -15,7 +15,7 @@ jobs:
             vendor:  '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/build-debug-rust.yaml
+++ b/.github/workflows/build-debug-rust.yaml
@@ -15,7 +15,7 @@ jobs:
             vendor:  '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/build-dotnet.yaml
+++ b/.github/workflows/build-dotnet.yaml
@@ -24,7 +24,7 @@ jobs:
             vendor:  '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/build-publish-torizon-dev.yaml
+++ b/.github/workflows/build-publish-torizon-dev.yaml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Fixup actions pipx paths
         run: |

--- a/.github/workflows/build-python.yaml
+++ b/.github/workflows/build-python.yaml
@@ -15,7 +15,7 @@ jobs:
             vendor:  '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -15,7 +15,7 @@ jobs:
             vendor:  '{ "arch": "arm64", "torizon_arch": "aarch64" }'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Get Host Absolute Workspace Path
         run: |

--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -9,7 +9,7 @@ jobs:
       image: node:23
     name: Spell Check
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: cspell CLI Lint
 
@@ -27,7 +27,7 @@ jobs:
       options: --user root
     name: Check EOF New Line
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check EOF New Line
 
@@ -43,7 +43,7 @@ jobs:
       options: --user root
     name: Check JSON
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check JSON
 
@@ -51,7 +51,7 @@ jobs:
 
         run: |
           xonsh ./scripts/validate-json.xsh
-  
+
   check-task-duplicates:
     runs-on: ubuntu-24.04
     container:
@@ -59,7 +59,7 @@ jobs:
       options: --user root
     name: Check Task Duplicates
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check Task Duplicates
 

--- a/.github/workflows/publish-torizon-utils.yaml
+++ b/.github/workflows/publish-torizon-utils.yaml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Sanity version
         run: |

--- a/.github/workflows/templates-ci-tests.yaml
+++ b/.github/workflows/templates-ci-tests.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout vscode-ci-cd-template-test (${{ matrix.branch }})
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: torizon/vscode-ci-cd-template-test
           ref: ${{ matrix.branch }}
@@ -26,7 +26,7 @@ jobs:
           token: ${{ secrets.CI_REPO_TOKEN }}
 
       - name: Checkout templates into .apollox
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: .apollox
 

--- a/assets/github/workflows/build-application.yaml
+++ b/assets/github/workflows/build-application.yaml
@@ -26,7 +26,7 @@ jobs:
       image: torizonextras/torizon-dev:dev
       options: --user root
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Initial Setup
         shell: bash

--- a/tcb/.github/workflows/build-torizoncore.yaml
+++ b/tcb/.github/workflows/build-torizoncore.yaml
@@ -20,7 +20,7 @@ jobs:
       image: torizonextras/torizon-dev:dev
       options: --user root
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Initial Setup
         shell: bash


### PR DESCRIPTION
actions/checkout@v5 uses the node 24 that fixes the deprecation warning